### PR TITLE
Disable Redis queue connections in development

### DIFF
--- a/src/jobs/queues/email.queue.ts
+++ b/src/jobs/queues/email.queue.ts
@@ -1,9 +1,20 @@
 import { Queue } from "bullmq";
 
-export const emailQueue = new Queue("email", {
-  connection: {
-    host: process.env.REDIS_HOST || "localhost",
-    port: Number(process.env.REDIS_PORT) || 6379,
-    password: process.env.REDIS_PASSWORD || undefined,
-  },
-});
+class MockQueue {
+  async add() {
+    console.warn(
+      "ℹ️ Email queue is disabled in development. Job not queued."
+    );
+  }
+}
+
+export const emailQueue =
+  process.env.NODE_ENV === "production"
+    ? new Queue("email", {
+        connection: {
+          host: process.env.REDIS_HOST || "localhost",
+          port: Number(process.env.REDIS_PORT) || 6379,
+          password: process.env.REDIS_PASSWORD || undefined,
+        },
+      })
+    : (new MockQueue() as any);

--- a/src/jobs/queues/notification.queue.ts
+++ b/src/jobs/queues/notification.queue.ts
@@ -1,12 +1,23 @@
 import { Queue } from "bullmq";
 
-export const notificationQueue = new Queue("notification", {
-  connection: {
-    host: process.env.REDIS_HOST || "localhost",
-    port: Number(process.env.REDIS_PORT) || 6379,
-    password: process.env.REDIS_PASSWORD || undefined,
-  },
-});
+class MockQueue {
+  async add() {
+    console.warn(
+      "ℹ️ Notification queue is disabled in development. Job not queued."
+    );
+  }
+}
+
+export const notificationQueue =
+  process.env.NODE_ENV === "production"
+    ? new Queue("notification", {
+        connection: {
+          host: process.env.REDIS_HOST || "localhost",
+          port: Number(process.env.REDIS_PORT) || 6379,
+          password: process.env.REDIS_PASSWORD || undefined,
+        },
+      })
+    : (new MockQueue() as any);
 
 // import { notificationQueue } from "../../jobs/queues/notification.queue";
 


### PR DESCRIPTION
## Summary
- avoid connecting to Redis for job queues when running in development

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run build` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_686b7897db58832494f872c226f25251