### PR TITLE
Fix CORS usage causing res.setHeader error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ export const startServer = async () => {
     }
     next();
   });
-  app.use(cors(corsConfig));
+  app.use(corsConfig);
   app.use(express.json());
   // app.use(
   //   session({


### PR DESCRIPTION
## Summary
- fix incorrect application of CORS middleware

## Testing
- `npm test` *(fails: jest not found)*
- `npm run dev` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7f32a0ec8324aefe826e93fb4980