### PR TITLE
Fix session generation in tests

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,4 +1,12 @@
-export const generateSession = async (req: any, userId: number, role: "user" | "admin") => {
+export const generateSession = async (
+  req: any,
+  userId: number,
+  role: "user" | "admin"
+) => {
+  if (!req.session) {
+    req.session = {};
+  }
+
   req.session.user = {
     id: userId,
     role,


### PR DESCRIPTION
## Summary
- handle missing `req.session` in `generateSession`

## Testing
- `npm run test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba3cde32483249efa66ced7b2c739