### PR TITLE
Add tests for user sub-routes

### DIFF
--- a/tests/helpers/expressAuthTestHelper.ts
+++ b/tests/helpers/expressAuthTestHelper.ts
@@ -1,0 +1,20 @@
+import express, { Router } from 'express';
+import request, { SuperTest, Test } from 'supertest';
+
+export interface AuthTestServer {
+  app: express.Express;
+  request: SuperTest<Test>;
+}
+
+export const createAuthTestServer = (router: Router, authenticated = true): AuthTestServer => {
+  const app = express();
+  app.use(express.json());
+  if (authenticated) {
+    app.use((req, _res, next) => {
+      (req as any).session = { user: { id: 1, role: 'user' } };
+      next();
+    });
+  }
+  app.use('/', router);
+  return { app, request: request(app) };
+};

--- a/tests/routes/notificationRoutes.test.ts
+++ b/tests/routes/notificationRoutes.test.ts
@@ -1,0 +1,72 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import notificationRoutes from '../../src/routes/user/notification';
+import * as notifRepo from '../../src/repositories/notification.repository';
+import * as notifJobs from '../../src/jobs/notification.jobs';
+
+jest.mock('../../src/repositories/notification.repository');
+jest.mock('../../src/jobs/notification.jobs');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(notificationRoutes);
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Notification Routes', () => {
+  describe('GET /user/notifications', () => {
+    it('should return notifications', async () => {
+      (notifRepo.findUserNotifications as jest.Mock).mockResolvedValueOnce([]);
+      const res = await server.request.get('/user/notifications');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 401 without session', async () => {
+      const unauth = createAuthTestServer(notificationRoutes, false);
+      const res = await unauth.request.get('/user/notifications');
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (notifRepo.findUserNotifications as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/user/notifications');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /user/notifications/status/change/:status', () => {
+    it('should update notification status', async () => {
+      (notifRepo.updateUserNotificationStatus as jest.Mock).mockResolvedValueOnce(1);
+      const res = await server.request.get('/user/notifications/status/change/read');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid param', async () => {
+      const res = await server.request.get('/user/notifications/status/change/bad');
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (notifRepo.updateUserNotificationStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/user/notifications/status/change/read');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /user/notifications/clear-all', () => {
+    it('should clear notifications', async () => {
+      (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockResolvedValueOnce(3);
+      const res = await server.request.get('/user/notifications/clear-all');
+      expect(res.status).toBe(200);
+    });
+
+    it('should handle server errors', async () => {
+      (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/user/notifications/clear-all');
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/passwordRoutes.test.ts
+++ b/tests/routes/passwordRoutes.test.ts
@@ -1,0 +1,85 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import passwordRoutes from '../../src/routes/user/password';
+import * as userRepo from '../../src/repositories/user.repository';
+import * as hashUtils from '../../src/utils/hash';
+import * as attemptUtils from '../../src/utils/passwordAttempt';
+import * as passwordJobs from '../../src/jobs/password.jobs';
+import { userEmitter } from '../../src/events/emitters/userEmitter';
+
+jest.mock('../../src/repositories/user.repository');
+jest.mock('../../src/utils/hash');
+jest.mock('../../src/utils/passwordAttempt');
+jest.mock('../../src/jobs/password.jobs');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(passwordRoutes);
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Password Routes', () => {
+  describe('POST /user/change/password', () => {
+    it('should change password successfully', async () => {
+      (attemptUtils.isBlocked as jest.Mock).mockResolvedValueOnce(false);
+      (userRepo.findUserWithPasswordById as jest.Mock).mockResolvedValueOnce({ id: 1, password: 'hashed' });
+      (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(true);
+      (hashUtils.hashPassword as jest.Mock).mockResolvedValueOnce('newhash');
+      const res = await server.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid payload', async () => {
+      const res = await server.request.post('/user/change/password').send({ current_password: '1', new_password: '2' });
+      expect(res.status).toBe(422);
+    });
+
+    it('should return 429 when blocked', async () => {
+      (attemptUtils.isBlocked as jest.Mock).mockResolvedValueOnce(true);
+      const res = await server.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(429);
+    });
+
+    it('should return 404 when user not found', async () => {
+      (attemptUtils.isBlocked as jest.Mock).mockResolvedValueOnce(false);
+      (userRepo.findUserWithPasswordById as jest.Mock).mockResolvedValueOnce(null);
+      const res = await server.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 401 when password mismatch', async () => {
+      (attemptUtils.isBlocked as jest.Mock).mockResolvedValueOnce(false);
+      (userRepo.findUserWithPasswordById as jest.Mock).mockResolvedValueOnce({ id: 1, password: 'hashed' });
+      (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(false);
+      const res = await server.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 401 without session', async () => {
+      const unauth = createAuthTestServer(passwordRoutes, false);
+      const res = await unauth.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (attemptUtils.isBlocked as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request
+        .post('/user/change/password')
+        .send({ current_password: 'oldpass', new_password: 'newpass' });
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/profileRoutes.test.ts
+++ b/tests/routes/profileRoutes.test.ts
@@ -1,0 +1,62 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import profileRoutes from '../../src/routes/user/profile';
+import * as userRepo from '../../src/repositories/user.repository';
+
+jest.mock('../../src/repositories/user.repository');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(profileRoutes);
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Profile Routes', () => {
+  describe('GET /user/me', () => {
+    it('should return profile for authenticated user', async () => {
+      (userRepo.findUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
+      const res = await server.request.get('/user/me');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 404 when user not found', async () => {
+      (userRepo.findUserById as jest.Mock).mockResolvedValueOnce(null);
+      const res = await server.request.get('/user/me');
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 401 without session', async () => {
+      const unauth = createAuthTestServer(profileRoutes, false);
+      const res = await unauth.request.get('/user/me');
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.findUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
+      const res = await server.request.get('/user/me');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('POST /user/update', () => {
+    it('should update user profile', async () => {
+      (userRepo.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
+      const res = await server.request.post('/user/update').send({ name: 'John', email: 'john@example.com' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid payload', async () => {
+      const res = await server.request.post('/user/update').send({ name: 'J', email: 'bad' });
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
+      const res = await server.request.post('/user/update').send({ name: 'John', email: 'john@example.com' });
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/sessionRoutes.test.ts
+++ b/tests/routes/sessionRoutes.test.ts
@@ -1,0 +1,40 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import sessionRoutes from '../../src/routes/user/session';
+import * as sessionUtils from '../../src/utils/session';
+import * as attemptUtils from '../../src/utils/passwordAttempt';
+import * as sessionJobs from '../../src/jobs/session.jobs';
+
+jest.mock('../../src/utils/session');
+jest.mock('../../src/utils/passwordAttempt');
+jest.mock('../../src/jobs/session.jobs');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(sessionRoutes);
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Session Routes', () => {
+  describe('GET /user/logout', () => {
+    it('should logout successfully', async () => {
+      const res = await server.request.get('/user/logout');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 401 without session', async () => {
+      const unauth = createAuthTestServer(sessionRoutes, false);
+      const res = await unauth.request.get('/user/logout');
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (sessionUtils.destroySession as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/user/logout');
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/userRoutes.test.ts
+++ b/tests/routes/userRoutes.test.ts
@@ -1,0 +1,36 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import userRoutes from '../../src/api/user.routes';
+import * as userRepo from '../../src/repositories/user.repository';
+import * as notifRepo from '../../src/repositories/notification.repository';
+
+jest.mock('../../src/repositories/user.repository');
+jest.mock('../../src/repositories/notification.repository');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(userRoutes);
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('User Router', () => {
+  it('should mount /auth routes', async () => {
+    const res = await server.request.post('/auth/login').send({ email: 'a@b.com', password: 'secret123' });
+    expect(res.status).not.toBe(404);
+  });
+
+  it('should mount /user/me route', async () => {
+    (userRepo.findUserById as jest.Mock).mockResolvedValueOnce({ id:1, name:'J', email:'a@b.com' });
+    const res = await server.request.get('/user/me');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('should mount notification routes', async () => {
+    (notifRepo.findUserNotifications as jest.Mock).mockResolvedValueOnce([]);
+    const res = await server.request.get('/user/notifications');
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to create authenticated test servers
- test profile, password, session and notification routes
- add high level router tests to ensure mounting works

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686ba6ffd0008324a5ba8f4181a22f0f