### PR TITLE
Fix auth route mount test

### DIFF
--- a/tests/routes/userRoutes.test.ts
+++ b/tests/routes/userRoutes.test.ts
@@ -14,6 +14,12 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.resetAllMocks();
+  (userRepo.findUserByEmail as jest.Mock).mockResolvedValue({
+    id: 1,
+    name: 'John',
+    email: 'a@b.com',
+    password: 'secret123',
+  });
 });
 
 describe('User Router', () => {


### PR DESCRIPTION
## Summary
- mock findUserByEmail so login route doesn't return 404

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba9bed7c88324aa46929b93bff203