### PR TITLE
Fix import for validateRequest in admin app link routes

### DIFF
--- a/src/routes/admin/appLink.ts
+++ b/src/routes/admin/appLink.ts
@@ -7,7 +7,7 @@ import {
   UpdateAppLinkParamSchema,
 } from "../../requests/admin/appLink.request";
 import { updateAppLinkHandler } from "./appLink.controller";
-import { validateRequest } from "../../middlewares/validateRequest";
+import validateRequest from "../../middlewares/validateRequest";
 
 
 


### PR DESCRIPTION
## Summary
- correct `validateRequest` import in `src/routes/admin/appLink.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc4fb17c48324a82689ed673783ee