### PR TITLE
Fix nodemon start issue by importing express type augmentations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import "./types/express";
 import { initSentry } from "./telemetry/sentry";
 import { startServer } from "./server";
 import { logger } from "./utils/logger";


### PR DESCRIPTION
## Summary
- fix global Request typing by importing `./types/express` in entry point

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest', etc.)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c01754afc83249f2e71f3a27cf912