### PR TITLE
Fix duplicate import in appLink controller

### DIFF
--- a/src/routes/admin/appLink.controller.ts
+++ b/src/routes/admin/appLink.controller.ts
@@ -20,7 +20,6 @@ import {
 import { updateAppLinkById } from "../../repositories/appLink.repository";
 import { logAppLinkUpdate } from "../../jobs/appLink.jobs";
 import { formatAppLink } from "../../resources/admin/appLink.resource";
-import { captureError } from "../../telemetry/sentry";
 
 export const updateAppLinkHandler = async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
## Summary
- fix compile error by removing duplicate `captureError` import

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c044e72b083249a6b0f3254b50e7f