### PR TITLE
Add JWT token issuance on login

### DIFF
--- a/postman_user_admin_collection.json
+++ b/postman_user_admin_collection.json
@@ -8,6 +8,10 @@
     {
       "key": "base_url",
       "value": "http://localhost:3000"
+    },
+    {
+      "key": "token",
+      "value": ""
     }
   ],
   "item": [
@@ -68,7 +72,20 @@
                   "host": ["{{base_url}}"],
                   "path": ["api", "auth", "login"]
                 }
-              }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "var json = pm.response.json();",
+                      "if (json.token) { pm.environment.set('token', json.token); }"
+                    ]
+                  }
+                }
+              ]
+            }
             },
             {
               "name": "Social Login",
@@ -153,17 +170,19 @@
         {
           "name": "Profile",
           "item": [
-            {
-              "name": "Get Profile",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/api/user/me",
-                  "host": ["{{base_url}}"],
-                  "path": ["api", "user", "me"]
+              {
+                "name": "Get Profile",
+                "request": {
+                  "method": "GET",
+                  "header": [
+                    { "key": "Authorization", "value": "Bearer {{token}}" }
+                  ],
+                  "url": {
+                    "raw": "{{base_url}}/api/user/me",
+                    "host": ["{{base_url}}"],
+                    "path": ["api", "user", "me"]
+                  }
                 }
-              }
             },
             {
               "name": "Update Profile",
@@ -252,40 +271,54 @@
         {
           "name": "Auth",
           "item": [
-            {
-              "name": "Admin Login",
-              "request": {
-                "method": "POST",
-                "header": [
-                  { "key": "Content-Type", "value": "application/json" }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"email\": \"admin@example.com\",\n  \"password\": \"adminpass\"\n}"
+              {
+                "name": "Admin Login",
+                "request": {
+                  "method": "POST",
+                  "header": [
+                    { "key": "Content-Type", "value": "application/json" }
+                  ],
+                  "body": {
+                    "mode": "raw",
+                    "raw": "{\n  \"email\": \"admin@example.com\",\n  \"password\": \"adminpass\"\n}"
+                  },
+                  "url": {
+                    "raw": "{{base_url}}/api/admin/login",
+                    "host": ["{{base_url}}"],
+                    "path": ["api", "admin", "login"]
+                  }
                 },
-                "url": {
-                  "raw": "{{base_url}}/api/admin/login",
-                  "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "login"]
-                }
+                "event": [
+                  {
+                    "listen": "test",
+                    "script": {
+                      "type": "text/javascript",
+                      "exec": [
+                        "var json = pm.response.json();",
+                        "if (json.token) { pm.environment.set('token', json.token); }"
+                      ]
+                    }
+                  }
+                ]
               }
-            }
           ]
         },
         {
           "name": "Profile",
           "item": [
-            {
-              "name": "Get Admin Profile",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/api/admin/me",
-                  "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "me"]
+              {
+                "name": "Get Admin Profile",
+                "request": {
+                  "method": "GET",
+                  "header": [
+                    { "key": "Authorization", "value": "Bearer {{token}}" }
+                  ],
+                  "url": {
+                    "raw": "{{base_url}}/api/admin/me",
+                    "host": ["{{base_url}}"],
+                    "path": ["api", "admin", "me"]
+                  }
                 }
-              }
             }
           ]
         },

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,19 +1,30 @@
 import { Request, Response, NextFunction } from "express";
 import { Messages } from "../constants/messages";
+import { verifyJwt } from "../utils/jwt";
 
 export const requireUserAuth = (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  if (
-    !(req.session as any)?.user ||
-    (req.session as any).user.role !== "user"
-  ) {
+  let user = (req.session as any)?.user;
+
+  if (!user) {
+    const auth = req.headers.authorization;
+    if (auth && auth.startsWith("Bearer ")) {
+      const token = auth.substring(7);
+      const payload = verifyJwt<{ id: number; role: string }>(token);
+      if (payload) {
+        user = { id: payload.id, role: payload.role as any };
+      }
+    }
+  }
+
+  if (!user || user.role !== "user") {
     return res.status(401).json({ message: Messages.unauthorized });
   }
 
-  req.user = (req.session as any).user;
+  req.user = user;
   next();
 };
 
@@ -22,13 +33,23 @@ export const requireAdminAuth = (
   res: Response,
   next: NextFunction
 ) => {
-  if (
-    !(req.session as any)?.user ||
-    (req.session as any).user.role !== "admin"
-  ) {
+  let user = (req.session as any)?.user;
+
+  if (!user) {
+    const auth = req.headers.authorization;
+    if (auth && auth.startsWith("Bearer ")) {
+      const token = auth.substring(7);
+      const payload = verifyJwt<{ id: number; role: string }>(token);
+      if (payload) {
+        user = { id: payload.id, role: payload.role as any };
+      }
+    }
+  }
+
+  if (!user || user.role !== "admin") {
     return res.status(401).json({ message: "Unauthorized" });
   }
 
-  req.user = (req.session as any).user;
+  req.user = user;
   next();
 };

--- a/src/routes/admin/auth.controller.ts
+++ b/src/routes/admin/auth.controller.ts
@@ -10,6 +10,7 @@ import { logAdminLogin } from "../../jobs/admin.jobs";
 import { AdminPassword } from "../../domain/valueObjects/adminPassword.vo";
 import { captureError } from "../../telemetry/sentry";
 import { appEmitter, APP_EVENTS } from "../../events/emitters/appEmitter";
+import { signJwt } from "../../utils/jwt";
 
 export const loginAdmin = async (req: Request, res: Response) => {
   try {
@@ -28,6 +29,7 @@ export const loginAdmin = async (req: Request, res: Response) => {
     const adminEntity = new AdminEntity(admin.id, admin.name, admin.email);
 
     await generateSession(req, admin.id, "admin");
+    const token = signJwt({ id: admin.id, role: "admin" });
     logAdminLogin(admin.id, admin.email);
 
     appEmitter.emit(APP_EVENTS.ADMIN_LOGGED_IN, {
@@ -39,6 +41,7 @@ export const loginAdmin = async (req: Request, res: Response) => {
     return res.json({
       message: AdminMessages.loginSuccess,
       admin: formatAdminResponse(adminEntity),
+      token,
     });
   } catch (error) {
     captureError(error, "adminLogin");

--- a/src/routes/user/auth.controller.ts
+++ b/src/routes/user/auth.controller.ts
@@ -22,6 +22,7 @@ import { Password } from "../../domain/valueObjects/password.vo";
 import { UserEntity } from "../../domain/entities/user.entity";
 import { appEmitter, APP_EVENTS } from "../../events/emitters/appEmitter";
 import { captureError } from "../../telemetry/sentry";
+import { signJwt } from "../../utils/jwt";
 
 const prisma = new PrismaClient();
 
@@ -91,6 +92,7 @@ const loginUser = async (req: Request, res: Response) => {
       userRecord.name,
       userRecord.email
     );
+    const token = signJwt({ id: userRecord.id, role: "user" });
 
     logLogin(emailVO.getValue());
     userEmitter.emit("user.loggedIn", {
@@ -101,6 +103,7 @@ const loginUser = async (req: Request, res: Response) => {
     return res.json({
       message: AuthMessages.login,
       user: formatUserResponse(userEntity),
+      token,
     });
   } catch (error) {
     captureError(error, "loginUser");

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+const base64url = (input: string | Buffer): string => {
+  return Buffer.from(input).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+};
+
+const fromBase64url = (input: string): Buffer => {
+  input = input.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = 4 - (input.length % 4);
+  if (pad !== 4) input += '='.repeat(pad);
+  return Buffer.from(input, 'base64');
+};
+
+export const signJwt = (payload: object): string => {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const headerB64 = base64url(JSON.stringify(header));
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const data = `${headerB64}.${payloadB64}`;
+  const signature = base64url(createHmac('sha256', JWT_SECRET).update(data).digest());
+  return `${data}.${signature}`;
+};
+
+export const verifyJwt = <T>(token: string): T | null => {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, signature] = parts;
+  const data = `${headerB64}.${payloadB64}`;
+  const expectedSig = base64url(createHmac('sha256', JWT_SECRET).update(data).digest());
+  if (expectedSig !== signature) return null;
+  try {
+    const payload = JSON.parse(fromBase64url(payloadB64).toString());
+    return payload as T;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- generate JWT tokens without external libs
- return token from admin and user login endpoints
- accept Authorization Bearer tokens in auth middleware
- update Postman collection with token variable and automatic extraction

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'jest' etc.)*
- `npm test` *(fails: jest: not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686ca61a26108324b02c837a12e18c99