### PR TITLE
Standardize API response format

### DIFF
--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { Messages } from "../constants/messages";
 import { verifyAuthToken } from "../utils/authToken";
 import { verifyJwt } from "../utils/jwt";
+import { error } from "../utils/responseWrapper";
 
 export const requireUserAuth = (
   req: Request,
@@ -23,7 +24,7 @@ export const requireUserAuth = (
   }
 
   if (!user || user.role !== "user") {
-    return res.status(401).json({ message: Messages.unauthorized });
+    return res.status(401).json(error(Messages.unauthorized));
   }
 
   req.user = user;
@@ -50,7 +51,7 @@ export const requireAdminAuth = (
   }
 
   if (!user || user.role !== "admin") {
-    return res.status(401).json({ message: "Unauthorized" });
+    return res.status(401).json(error("Unauthorized"));
   }
 
   req.user = user;

--- a/src/middlewares/globalRateLimiter.ts
+++ b/src/middlewares/globalRateLimiter.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { createClient } from "redis";
+import { error } from "../utils/responseWrapper";
 
 // In-memory rate limiting fallback
 const memoryStore = new Map<string, { count: number; resetTime: number }>();
@@ -51,11 +52,14 @@ export const globalRateLimiter = async (
       }
 
       if (current > limit) {
-        return res.status(429).json({
-          message: "Too many requests — please slow down.",
-          route: path,
-          retry_after: window,
-        });
+        return res
+          .status(429)
+          .json(
+            error("Too many requests — please slow down.", {
+              route: path,
+              retry_after: window,
+            })
+          );
       }
     } else {
       // Use in-memory store as fallback
@@ -68,11 +72,14 @@ export const globalRateLimiter = async (
       } else {
         record.count++;
         if (record.count > limit) {
-          return res.status(429).json({
-            message: "Too many requests — please slow down.",
-            route: path,
-            retry_after: window,
-          });
+          return res
+            .status(429)
+            .json(
+              error("Too many requests — please slow down.", {
+                route: path,
+                retry_after: window,
+              })
+            );
         }
       }
     }

--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { createClient } from "redis";
+import { error } from "../utils/responseWrapper";
 
 // In-memory rate limiting fallback
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
@@ -40,9 +41,9 @@ export const rateLimiter = ({
           await redis.expire(key, windowInSeconds);
         }
         if (current > limit) {
-          return res.status(429).json({
-            message: "Too many requests. Please try again later.",
-          });
+          return res
+            .status(429)
+            .json(error("Too many requests. Please try again later."));
         }
       } else {
         // Use in-memory store for development
@@ -55,9 +56,9 @@ export const rateLimiter = ({
         } else {
           record.count++;
           if (record.count > limit) {
-            return res.status(429).json({
-              message: "Too many requests. Please try again later.",
-            });
+            return res
+              .status(429)
+              .json(error("Too many requests. Please try again later."));
           }
         }
       }

--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { ZodError } from "zod";
 import { formatZodError } from "../utils/zodErrorFormatter";
+import { error } from "../utils/responseWrapper";
 
 export default function validateRequest({
   body,
@@ -19,13 +20,12 @@ export default function validateRequest({
       next();
     } catch (error) {
       if (error instanceof ZodError) {
-        return res.status(422).json({
-          message: "Validation failed",
-          errors: formatZodError(error),
-        });
+        return res
+          .status(422)
+          .json(error("Validation failed", formatZodError(error)));
       }
 
-      return res.status(500).json({ message: "Unexpected validation error" });
+      return res.status(500).json(error("Unexpected validation error"));
     }
   };
 }

--- a/src/routes/admin/appLink.controller.ts
+++ b/src/routes/admin/appLink.controller.ts
@@ -2,14 +2,15 @@ import { Request, Response } from "express";
 import { getAppLinks } from "../../repositories/appLink.repository";
 import { formatAppLinksList } from "../../resources/admin/appLink.resource";
 import { captureError } from "../../telemetry/sentry";
+import { success, error } from "../../utils/responseWrapper";
 
 export const getAppLinksHandler = async (req: Request, res: Response) => {
   try {
     const links = await getAppLinks();
-    return res.json({ links: formatAppLinksList(links) });
-  } catch (error) {
-    captureError(error, "getAppLinks");
-    return res.status(500).json({ message: "Failed to load app links" });
+    return res.json(success("Links fetched", formatAppLinksList(links)));
+  } catch (err) {
+    captureError(err, "getAppLinks");
+    return res.status(500).json(error("Failed to load app links"));
   }
 };
 
@@ -30,12 +31,11 @@ export const updateAppLinkHandler = async (req: Request, res: Response) => {
 
     logAppLinkUpdate(Number(id));
 
-    return res.json({
-      message: "Link updated",
-      link: formatAppLink(updated),
-    });
-  } catch (error) {
-    captureError(error, "updateAppLink");
-    return res.status(500).json({ message: "Failed to update app link" });
+    return res.json(
+      success("Link updated", formatAppLink(updated))
+    );
+  } catch (err) {
+    captureError(err, "updateAppLink");
+    return res.status(500).json(error("Failed to update app link"));
   }
 };

--- a/src/routes/admin/appSetting.controller.ts
+++ b/src/routes/admin/appSetting.controller.ts
@@ -16,6 +16,7 @@ import { logAppSettingUpdated } from "../../jobs/appSetting.jobs";
 import { DeleteAppSettingParamSchema } from "../../requests/admin/appSetting.request";
 import { softDeleteAppSetting } from "../../repositories/appSetting.repository";
 import { logAppSettingDeleted } from "../../jobs/appSetting.jobs";
+import { success, error } from "../../utils/responseWrapper";
 
 export const getAppSettings = async (req: Request, res: Response) => {
   try {
@@ -28,13 +29,15 @@ export const getAppSettings = async (req: Request, res: Response) => {
       order: parsed.order,
     });
 
-    return res.json({
-      settings: formatAppSettingsList(data),
-      pagination,
-    });
+    return res.json(
+      success("App settings fetched", {
+        settings: formatAppSettingsList(data),
+        pagination,
+      })
+    );
   } catch (error) {
     captureError(error, "getAppSettings");
-    return res.status(500).json({ message: "Failed to fetch app settings" });
+    return res.status(500).json(error("Failed to fetch app settings"));
   }
 };
 
@@ -47,13 +50,12 @@ export const createAppSettingHandler = async (req: Request, res: Response) => {
 
     logAppSettingCreated(body.app_type);
 
-    return res.status(201).json({
-      message: "App setting created",
-      setting: formatAppSetting(setting),
-    });
+    return res.status(201).json(
+      success("App setting created", formatAppSetting(setting))
+    );
   } catch (error) {
     captureError(error, "createAppSetting");
-    return res.status(500).json({ message: "Failed to create app setting" });
+    return res.status(500).json(error("Failed to create app setting"));
   }
 };
 
@@ -67,13 +69,12 @@ export const updateAppSettingHandler = async (req: Request, res: Response) => {
 
     logAppSettingUpdated(Number(id));
 
-    return res.json({
-      message: "App setting updated",
-      setting: formatAppSetting(setting),
-    });
+    return res.json(
+      success("App setting updated", formatAppSetting(setting))
+    );
   } catch (error) {
     captureError(error, "updateAppSetting");
-    return res.status(500).json({ message: "Failed to update app setting" });
+    return res.status(500).json(error("Failed to update app setting"));
   }
 };
 
@@ -86,9 +87,9 @@ export const deleteAppSettingHandler = async (req: Request, res: Response) => {
 
     logAppSettingDeleted(Number(id));
 
-    return res.json({ message: "App setting deleted successfully" });
+    return res.json(success("App setting deleted successfully"));
   } catch (error) {
     captureError(error, "deleteAppSetting");
-    return res.status(500).json({ message: "Failed to delete app setting" });
+    return res.status(500).json(error("Failed to delete app setting"));
   }
 };

--- a/src/routes/admin/appVariable.controller.ts
+++ b/src/routes/admin/appVariable.controller.ts
@@ -12,16 +12,17 @@ import {
 } from "../../requests/admin/appVariable.request";
 import { updateAppVariable } from "../../repositories/appVariable.repository";
 import { logAppVariableUpdated } from "../../jobs/appVariable.jobs";
+import { success, error } from "../../utils/responseWrapper";
 
 
 
 export const getAppVariablesHandler = async (req: Request, res: Response) => {
   try {
     const vars = await getAppVariables();
-    return res.json({ variables: formatAppVariableList(vars) });
-  } catch (error) {
-    captureError(error, "getAppVariables");
-    return res.status(500).json({ message: "Failed to load app variables" });
+    return res.json(success("Variables fetched", formatAppVariableList(vars)));
+  } catch (err) {
+    captureError(err, "getAppVariables");
+    return res.status(500).json(error("Failed to load app variables"));
   }
 };
 
@@ -32,13 +33,12 @@ export const createAppVariableHandler = async (req: Request, res: Response) => {
     const variable = await createAppVariable(body);
     logAppVariableCreated(body.name);
 
-    return res.status(201).json({
-      message: "App variable created",
-      variable: formatAppVariable(variable),
-    });
-  } catch (error) {
-    captureError(error, "createAppVariable");
-    return res.status(500).json({ message: "Failed to create app variable" });
+    return res.status(201).json(
+      success("App variable created", formatAppVariable(variable))
+    );
+  } catch (err) {
+    captureError(err, "createAppVariable");
+    return res.status(500).json(error("Failed to create app variable"));
   }
 };
 
@@ -50,12 +50,11 @@ export const updateAppVariableHandler = async (req: Request, res: Response) => {
     const updated = await updateAppVariable(Number(id), body);
     logAppVariableUpdated(Number(id));
 
-    return res.json({
-      message: "App variable updated",
-      variable: formatAppVariable(updated),
-    });
-  } catch (error) {
-    captureError(error, "updateAppVariable");
-    return res.status(500).json({ message: "Failed to update app variable" });
+    return res.json(
+      success("App variable updated", formatAppVariable(updated))
+    );
+  } catch (err) {
+    captureError(err, "updateAppVariable");
+    return res.status(500).json(error("Failed to update app variable"));
   }
 };

--- a/src/routes/admin/export.controller.ts
+++ b/src/routes/admin/export.controller.ts
@@ -5,6 +5,7 @@ import { logUserExport } from "../../jobs/export.jobs";
 import { Parser } from "json2csv";
 import XLSX from "xlsx";
 import { captureError } from "../../telemetry/sentry";
+import { error } from "../../utils/responseWrapper";
 
 export const exportUsersHandler = async (req: Request, res: Response) => {
   try {
@@ -35,9 +36,9 @@ export const exportUsersHandler = async (req: Request, res: Response) => {
       return res.send(buffer);
     }
 
-    return res.status(400).json({ message: "Unsupported export type" });
-  } catch (error) {
-    captureError(error, "exportUsers");
-    return res.status(500).json({ message: "Failed to export users" });
+    return res.status(400).json(error("Unsupported export type"));
+  } catch (err) {
+    captureError(err, "exportUsers");
+    return res.status(500).json(error("Failed to export users"));
   }
 };

--- a/src/routes/admin/profile.controller.ts
+++ b/src/routes/admin/profile.controller.ts
@@ -3,6 +3,7 @@ import { findAdminById } from "../../repositories/admin.repository";
 import { formatAdminResponse } from "../../resources/admin/admin.resource";
 import { AdminMessages } from "../../constants/messages";
 import { captureError } from "../../telemetry/sentry";
+import { success, error } from "../../utils/responseWrapper";
 
 export const getAdminProfile = async (req: Request, res: Response) => {
   try {
@@ -10,12 +11,12 @@ export const getAdminProfile = async (req: Request, res: Response) => {
     const admin = await findAdminById(adminId);
 
     if (!admin) {
-      return res.status(404).json({ message: AdminMessages.notFound });
+      return res.status(404).json(error(AdminMessages.notFound));
     }
 
-    return res.json({ admin: formatAdminResponse(admin) });
-  } catch (error) {
-    captureError(error, "getAdminProfile");
-    return res.status(500).json({ message: "Failed to load admin profile" });
+    return res.json(success("Admin fetched", formatAdminResponse(admin)));
+  } catch (err) {
+    captureError(err, "getAdminProfile");
+    return res.status(500).json(error("Failed to load admin profile"));
   }
 };

--- a/src/routes/admin/user.controller.ts
+++ b/src/routes/admin/user.controller.ts
@@ -22,16 +22,17 @@ import {
   logUserToggled,
   logUserDeleted,
 } from "../../jobs/user.jobs";
+import { success, error } from "../../utils/responseWrapper";
 
 const prisma = new PrismaClient();
 
 export const getAllUsersHandler = async (req: Request, res: Response) => {
   try {
     const users = await getAllUsers();
-    return res.json({ users: formatUserListForAdmin(users) });
-  } catch (error) {
-    captureError(error, "getAllUsers");
-    return res.status(500).json({ message: "Failed to load users" });
+    return res.json(success("Users fetched", formatUserListForAdmin(users)));
+  } catch (err) {
+    captureError(err, "getAllUsers");
+    return res.status(500).json(error("Failed to load users"));
   }
 };
 
@@ -44,13 +45,12 @@ export const updateUserHandler = async (req: Request, res: Response) => {
 
     logUserUpdated(Number(id));
 
-    return res.json({
-      message: "User updated successfully",
-      user: formatUserForAdmin(updated),
-    });
-  } catch (error) {
-    captureError(error, "updateUser");
-    return res.status(500).json({ message: "Failed to update user" });
+    return res.json(
+      success("User updated successfully", formatUserForAdmin(updated))
+    );
+  } catch (err) {
+    captureError(err, "updateUser");
+    return res.status(500).json(error("Failed to update user"));
   }
 };
 
@@ -61,13 +61,12 @@ export const toggleUserStatusHandler = async (req: Request, res: Response) => {
 
     logUserToggled(user.id, user.status);
 
-    return res.json({
-      message: `User ${user.status ? "activated" : "deactivated"}`,
-      user: formatUserForAdmin(user),
-    });
-  } catch (error) {
-    captureError(error, "toggleUserStatus");
-    return res.status(500).json({ message: "Failed to toggle user" });
+    return res.json(
+      success(`User ${user.status ? "activated" : "deactivated"}`, formatUserForAdmin(user))
+    );
+  } catch (err) {
+    captureError(err, "toggleUserStatus");
+    return res.status(500).json(error("Failed to toggle user"));
   }
 };
 
@@ -78,12 +77,11 @@ export const deleteUserHandler = async (req: Request, res: Response) => {
 
     logUserDeleted(user.id);
 
-    return res.json({
-      message: "User deleted successfully",
-      user: formatUserForAdmin(user),
-    });
-  } catch (error) {
-    captureError(error, "deleteUser");
-    return res.status(500).json({ message: "Failed to delete user" });
+    return res.json(
+      success("User deleted successfully", formatUserForAdmin(user))
+    );
+  } catch (err) {
+    captureError(err, "deleteUser");
+    return res.status(500).json(error("Failed to delete user"));
   }
 };

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,15 +1,18 @@
 import { Router } from "express";
+import { success } from "../utils/responseWrapper";
 
 const router = Router();
 
 router.get("/", (req, res) => {
-  res.status(200).json({
-    status: true,
-    message: "Server is running",
-    uptime: process.uptime(),
-    timestamp: Date.now(),
-    version: process.env.npm_package_version,
-  });
+  res
+    .status(200)
+    .json(
+      success("Server is running", {
+        uptime: process.uptime(),
+        timestamp: Date.now(),
+        version: process.env.npm_package_version,
+      })
+    );
 });
 
 export default router;

--- a/src/routes/user/init.controller.ts
+++ b/src/routes/user/init.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { formatInitAppResponse } from "../../resources/user/init.resource";
+import { success, error } from "../../utils/responseWrapper";
 
 const prisma = new PrismaClient();
 
@@ -13,12 +14,12 @@ export const initApp = async (req: Request, res: Response) => {
     });
 
     if (!setting) {
-      return res.status(404).json({ message: "App settings not found" });
+      return res.status(404).json(error("App settings not found"));
     }
 
-    return res.json(formatInitAppResponse(setting));
-  } catch (error) {
-    console.error("InitApp Error:", error);
-    return res.status(500).json({ message: "Server error" });
+    return res.json(success("App settings fetched", formatInitAppResponse(setting)));
+  } catch (err) {
+    console.error("InitApp Error:", err);
+    return res.status(500).json(error("Server error"));
   }
 };

--- a/src/routes/user/notification.controller.ts
+++ b/src/routes/user/notification.controller.ts
@@ -8,15 +8,16 @@ import { logNotificationStatusChange } from "../../jobs/notification.jobs";
 import { deleteAllNotificationsForUser } from "../../repositories/notification.repository";
 import { logNotificationClear } from "../../jobs/notification.jobs";
 import { Messages } from "../../constants/messages";
+import { success, error } from "../../utils/responseWrapper";
 
 export const getNotifications = async (req: Request, res: Response) => {
   try {
     const userId = req.user!.id;
     const notifications = await findUserNotifications(userId);
-    return res.json({ notifications: formatNotificationList(notifications) });
-  } catch (error) {
-    captureError(error, "getNotifications");
-    return res.status(500).json({ message: "Failed to load notifications" });
+    return res.json(success("Notifications fetched", formatNotificationList(notifications)));
+  } catch (err) {
+    captureError(err, "getNotifications");
+    return res.status(500).json(error("Failed to load notifications"));
   }
 };
 
@@ -31,12 +32,12 @@ export const changeNotificationStatus = async (req: Request, res: Response) => {
     );
     logNotificationStatusChange(userId, status, updatedCount);
 
-    return res.json({ message: `Marked ${updatedCount} as ${status}` });
-  } catch (error) {
-    captureError(error, "changeNotificationStatus");
+    return res.json(success(`Marked ${updatedCount} as ${status}`));
+  } catch (err) {
+    captureError(err, "changeNotificationStatus");
     return res
       .status(500)
-      .json({ message: "Failed to update notification status" });
+      .json(error("Failed to update notification status"));
   }
 };
 
@@ -48,12 +49,11 @@ export const clearAllNotifications = async (req: Request, res: Response) => {
 
     logNotificationClear(userId, deletedCount);
 
-    return res.json({
-      message: Messages.clearNotifications,
-      deleted: deletedCount,
-    });
-  } catch (error) {
-    captureError(error, "clearAllNotifications");
-    return res.status(500).json({ message: "Failed to clear notifications" });
+    return res.json(
+      success(Messages.clearNotifications, { deleted: deletedCount })
+    );
+  } catch (err) {
+    captureError(err, "clearAllNotifications");
+    return res.status(500).json(error("Failed to clear notifications"));
   }
 };

--- a/src/routes/user/profile.controller.ts
+++ b/src/routes/user/profile.controller.ts
@@ -19,13 +19,11 @@ export const getProfile = async (req: Request, res: Response) => {
     const user = await findUserById(userId!);
 
     if (!user) {
-      return res.status(404).json({ message: Messages.userNotFound });
+      return res.status(404).json(error(Messages.userNotFound));
     }
 
     // return res.json({ user: formatUserResponse(user) });
-    return res.json(
-      success(formatUserResponse(user), "User fetched successfully")
-    );
+    return res.json(success("User fetched successfully", formatUserResponse(user)));
   } catch (err) {
     captureError(err, "getProfile");
     // return res.status(500).json({ message: "Server error" });
@@ -55,12 +53,11 @@ export const updateProfile = async (req: Request, res: Response) => {
       updatedUser.email
     );
 
-    return res.json({
-      message: "Profile updated successfully",
-      user: formatUserResponse(userEntity),
-    });
-  } catch (error) {
-    captureError(error, "updateProfile");
-    return res.status(500).json({ message: "Update failed" });
+    return res.json(
+      success("Profile updated successfully", formatUserResponse(userEntity))
+    );
+  } catch (err) {
+    captureError(err, "updateProfile");
+    return res.status(500).json(error("Update failed"));
   }
 };

--- a/src/routes/user/session.controller.ts
+++ b/src/routes/user/session.controller.ts
@@ -5,6 +5,7 @@ import { invalidateAuthToken } from "../../utils/authToken";
 import { logLogout } from "../../jobs/session.jobs";
 import { captureError } from "../../telemetry/sentry";
 import { Messages } from "../../constants/messages";
+import { success, error } from "../../utils/responseWrapper";
 
 export const logout = async (req: Request, res: Response) => {
   try {
@@ -15,9 +16,9 @@ export const logout = async (req: Request, res: Response) => {
     invalidateAuthToken(userId!);
     logLogout(userId!);
 
-    return res.json({ message: Messages.logoutSuccess });
-  } catch (error) {
-    captureError(error, "logout");
-    return res.status(500).json({ message: "Logout failed" });
+    return res.json(success(Messages.logoutSuccess));
+  } catch (err) {
+    captureError(err, "logout");
+    return res.status(500).json(error("Logout failed"));
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import sessionConfig from "./config/session.config";
 import { globalRateLimiter } from "./middlewares/globalRateLimiter";
 import { globalErrorHandler } from "./middlewares/errorHandler";
 import { requestLogger } from "./middlewares/requestLogger";
+import { success, error } from "./utils/responseWrapper";
 // import "../events/listeners/user.listener";
 // import "../events/listeners/admin.listener";
 
@@ -50,9 +51,7 @@ export const startServer = async () => {
   app.use((req, res, next) => {
     if (typeof res.setHeader !== "function") {
       console.error("res.setHeader is not a function!", res);
-      return res
-        .status(500)
-        .json({ success: false, message: "res.setHeader is not a function" });
+      return res.status(500).json(error("res.setHeader is not a function"));
     }
     next();
   });
@@ -69,11 +68,7 @@ export const startServer = async () => {
 
   // root route
   app.get("/", (req, res) => {
-    // res.status(200).json({ message: "Hello World" });
-    res.status(200).json({
-      status: true,
-      message: "Hello World",
-    });
+    res.status(200).json(success("Hello World"));
   });
 
   // Health check

--- a/src/utils/responseWrapper.ts
+++ b/src/utils/responseWrapper.ts
@@ -1,26 +1,29 @@
 type SuccessResponse<T> = {
-  success: true;
-  data: T;
-  message?: string;
+  status: true;
+  message: string;
+  data?: T;
 };
 
-type ErrorResponse = {
-  success: false;
+type ErrorResponse<T> = {
+  status: false;
   message: string;
-  errors?: any;
+  data?: T;
 };
 
 export const success = <T = any>(
-  data: T,
-  message?: string
+  message: string,
+  data?: T
 ): SuccessResponse<T> => ({
-  success: true,
-  data,
+  status: true,
   message,
+  data,
 });
 
-export const error = (message: string, errors?: any): ErrorResponse => ({
-  success: false,
+export const error = <T = any>(
+  message: string,
+  data?: T
+): ErrorResponse<T> => ({
+  status: false,
   message,
-  errors,
+  data,
 });


### PR DESCRIPTION
## Summary
- ensure server route handlers use `success`/`error` wrappers
- use response wrappers in middlewares for consistent structure
- implement uniform response helpers with `status`, `message` and optional `data`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0143a8c8324aee5335439fdf60b