### PR TITLE
Fix validation middleware compile error

### DIFF
--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -18,11 +18,11 @@ export default function validateRequest({
       if (query) req.query = query.parse(req.query);
       if (params) req.params = params.parse(req.params);
       next();
-    } catch (error) {
-      if (error instanceof ZodError) {
+    } catch (err) {
+      if (err instanceof ZodError) {
         return res
           .status(422)
-          .json(error("Validation failed", formatZodError(error)));
+          .json(error("Validation failed", formatZodError(err)));
       }
 
       return res.status(500).json(error("Unexpected validation error"));


### PR DESCRIPTION
## Summary
- fix variable shadowing in `validateRequest`

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc9ed9cc88324918eec9b465319ed