### PR TITLE
Add password reset functionality

### DIFF
--- a/src/requests/user/password.request.ts
+++ b/src/requests/user/password.request.ts
@@ -4,3 +4,11 @@ export const ChangePasswordRequestSchema = z.object({
   current_password: z.string().min(6),
   new_password: z.string().min(6),
 });
+
+export const ResetPasswordBodySchema = z.object({
+  new_password: z.string().min(6),
+});
+
+export const ResetPasswordParamsSchema = z.object({
+  token: z.string().uuid(),
+});

--- a/src/routes/reset.view.ts
+++ b/src/routes/reset.view.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/reset-password/:token", (req, res) => {
+  const { token } = req.params;
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Reset Password</title>
+</head>
+<body>
+  <h1>Reset Password</h1>
+  <form id="resetForm">
+    <input type="password" id="password" placeholder="New password" required />
+    <button type="submit">Submit</button>
+  </form>
+  <div id="message"></div>
+  <script>
+    const form = document.getElementById('resetForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const password = document.getElementById('password').value;
+      const res = await fetch('/api/reset-password/${token}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_password: password })
+      });
+      const data = await res.json();
+      document.getElementById('message').innerText = data.message || 'Error';
+    });
+  </script>
+</body>
+</html>`;
+  res.setHeader("Content-Type", "text/html");
+  res.send(html);
+});
+
+export default router;

--- a/src/routes/user/password.ts
+++ b/src/routes/user/password.ts
@@ -1,8 +1,12 @@
 import { Router } from "express";
-import { changePassword } from "./password.controller";
+import { changePassword, resetPassword } from "./password.controller";
 import { requireUserAuth } from "../../middlewares/authMiddleware";
 import validateRequest from "../../middlewares/validateRequest";
-import { ChangePasswordRequestSchema } from "../../requests/user/password.request";
+import {
+  ChangePasswordRequestSchema,
+  ResetPasswordBodySchema,
+  ResetPasswordParamsSchema,
+} from "../../requests/user/password.request";
 import { logRoute } from "../../decorators/logRoute";
 
 const router = Router();
@@ -13,6 +17,15 @@ router.post(
   requireUserAuth,
   validateRequest({ body: ChangePasswordRequestSchema }),
   changePassword
+);
+
+router.post(
+  "/reset-password/:token",
+  validateRequest({
+    params: ResetPasswordParamsSchema,
+    body: ResetPasswordBodySchema,
+  }),
+  resetPassword
 );
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import adminRoutes from "./api/admin.routes";
 import healthRoutes from "./api/health.routes";
 import docsRoutes from "./api/docs.routes";
 import bullBoardRoutes from "./api/bull.routes";
+import resetViewRoutes from "./routes/reset.view";
 
 export const startServer = async () => {
   const app = express();
@@ -70,6 +71,9 @@ export const startServer = async () => {
   app.get("/", (req, res) => {
     res.status(200).json(success("Hello World"));
   });
+
+  // Password reset view
+  app.use("/", resetViewRoutes);
 
   // Health check
   app.use("/api/health", healthRoutes);

--- a/src/utils/resetToken.ts
+++ b/src/utils/resetToken.ts
@@ -38,3 +38,11 @@ export const getUserIdFromToken = async (token: string) => {
     return null;
   }
 };
+
+export const deleteResetToken = async (token: string) => {
+  if (redisClient && process.env.NODE_ENV === "production") {
+    await redisClient.del(`${ResetPasswordConstants.keyPrefix}${token}`);
+  } else {
+    resetTokenStore.delete(token);
+  }
+};


### PR DESCRIPTION
## Summary
- support password reset token deletion
- expose reset password API
- adjust reset URL prefix for API usage
- test password reset flow
- **add password reset web view and restore public reset link**

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3dcfc0e88324920e32e87eb8cc78