### PR TITLE
Sanitize env vars and unify logging

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ NODE_ENV=development
 
 # Database
 # DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
-DATABASE_URL="mysql://root:@localhost:3306/typescript_node_starter_kit"
+DATABASE_URL="mysql://user:password@localhost:3306/app_db"
 
 # MYSQL_HOST="localhost"
 # MYSQL_USER="root"
@@ -23,8 +23,8 @@ JWT_SECRET=your_jwt_secret
 SESSION_SECRET=session_
 
 # Mail
-SMTP_HOST=smtp.gmail.com
+SMTP_HOST=smtp.example.com
 SMTP_PORT=587
-SMTP_USER=rignesh.eww@gmail.com
-SMTP_PASS=zhaukrypggqbjwsl
-MAIL_FROM=rignesh.eww@gmail.com
+SMTP_USER=user@example.com
+SMTP_PASS=your_password
+MAIL_FROM=no-reply@example.com

--- a/src/config/redis.config.ts
+++ b/src/config/redis.config.ts
@@ -1,5 +1,6 @@
 // Conditional Redis import to avoid connection attempts in development
 import { isProduction } from "./env";
+import { logger } from "../utils/logger";
 
 let redisClient: any = null;
 
@@ -11,13 +12,13 @@ if (isProduction) {
       port: Number(process.env.REDIS_PORT) || 6379,
       password: process.env.REDIS_PASSWORD || undefined,
     });
-    console.info("✅ Redis client created for production");
+    logger.info("✅ Redis client created for production");
   } catch (error) {
-    console.warn("⚠️ Failed to create Redis client:", error);
+    logger.warn("⚠️ Failed to create Redis client:", error);
     redisClient = null;
   }
 } else {
-  console.info("ℹ️ Redis client disabled for development");
+  logger.info("ℹ️ Redis client disabled for development");
 }
 
 export { redisClient };

--- a/src/decorators/logRoute.ts
+++ b/src/decorators/logRoute.ts
@@ -1,6 +1,8 @@
+import { logger } from "../utils/logger";
+
 export const logRoute = (routeName: string) => {
   return function (req: any, res: any, next: () => void) {
-    console.log(`[${routeName}] Hit at: ${new Date().toISOString()}`);
+    logger.info(`[${routeName}] Hit at: ${new Date().toISOString()}`);
     next();
   };
 };

--- a/src/events/listeners/admin.listener.ts
+++ b/src/events/listeners/admin.listener.ts
@@ -1,6 +1,7 @@
 import { appEmitter, APP_EVENTS } from "../emitters/appEmitter";
+import { logger } from "../../utils/logger";
 
 appEmitter.on(APP_EVENTS.ADMIN_LOGGED_IN, (payload) => {
-  console.log("🔐 Admin logged in:", payload.email);
+  logger.info("🔐 Admin logged in:", payload.email);
   // Track login time, security log, etc.
 });

--- a/src/events/listeners/user.listener.ts
+++ b/src/events/listeners/user.listener.ts
@@ -2,9 +2,10 @@ import { appEmitter, APP_EVENTS } from "../emitters/appEmitter";
 import { sendMail } from "../../utils/sendMail";
 import { userWelcomeEmail } from "../../templates/mail/userWelcomeEmail";
 import { emailQueue } from "../../jobs/queues/email.queue";
+import { logger } from "../../utils/logger";
 
 appEmitter.on(APP_EVENTS.USER_REGISTERED, (payload) => {
-  console.log("📩 New user registered:", payload.email);
+  logger.info("📩 New user registered:", payload.email);
   // Optionally send welcome email or track analytics
 });
 

--- a/src/jobs/queues/email.queue.ts
+++ b/src/jobs/queues/email.queue.ts
@@ -1,9 +1,10 @@
 import { Queue } from "bullmq";
 import { isProduction } from "../../config/env";
+import { logger } from "../../utils/logger";
 
 class MockQueue {
   async add() {
-    console.warn(
+    logger.warn(
       "ℹ️ Email queue is disabled in development. Job not queued."
     );
   }

--- a/src/jobs/queues/notification.queue.ts
+++ b/src/jobs/queues/notification.queue.ts
@@ -1,9 +1,10 @@
 import { Queue } from "bullmq";
 import { isProduction } from "../../config/env";
+import { logger } from "../../utils/logger";
 
 class MockQueue {
   async add() {
-    console.warn(
+    logger.warn(
       "ℹ️ Notification queue is disabled in development. Job not queued."
     );
   }

--- a/src/jobs/workers/email.worker.ts
+++ b/src/jobs/workers/email.worker.ts
@@ -3,6 +3,7 @@ import { createClient } from "redis";
 import { sendMail } from "../../utils/sendMail";
 import { userWelcomeEmail } from "../../templates/mail/userWelcomeEmail";
 import { isProduction } from "../../config/env";
+import { logger } from "../../utils/logger";
 
 let connection: any = null;
 let emailWorker: any = null;
@@ -24,17 +25,17 @@ if (isProduction) {
     );
 
     emailWorker.on("completed", (job) => {
-      console.log(`✅ Job ${job.id} completed`);
+      logger.info(`✅ Job ${job.id} completed`);
     });
 
     emailWorker.on("failed", (job, err) => {
-      console.error(`❌ Job ${job?.id} failed:`, err.message);
+      logger.error(`❌ Job ${job?.id} failed:`, err.message);
     });
   } catch (error) {
-    console.warn("⚠️ Redis not available for email worker");
+    logger.warn("⚠️ Redis not available for email worker");
   }
 } else {
-  console.info("ℹ️ Email worker disabled in development mode");
+  logger.info("ℹ️ Email worker disabled in development mode");
 }
 
 export { emailWorker };

--- a/src/jobs/workers/notification.worker.ts
+++ b/src/jobs/workers/notification.worker.ts
@@ -1,6 +1,7 @@
 import { Worker } from "bullmq";
 import { createClient } from "redis";
 import { isProduction } from "../../config/env";
+import { logger } from "../../utils/logger";
 
 let connection: any = null;
 let notificationWorker: any = null;
@@ -13,7 +14,7 @@ if (isProduction) {
       async (job) => {
         if (job.name === "pushInApp") {
           const { userId, title, body } = job.data;
-          console.log(
+          logger.info(
             `📲 Send notification to user#${userId}: ${title} - ${body}`
           );
           // TODO: call Notification.create() or Firebase push
@@ -23,17 +24,17 @@ if (isProduction) {
     );
 
     notificationWorker.on("completed", (job) => {
-      console.log(`✅ Notification job ${job.id} sent`);
+      logger.info(`✅ Notification job ${job.id} sent`);
     });
 
     notificationWorker.on("failed", (job, err) => {
-      console.error(`❌ Notification job ${job?.id} failed:`, err.message);
+      logger.error(`❌ Notification job ${job?.id} failed:`, err.message);
     });
   } catch (error) {
-    console.warn("⚠️ Redis not available for notification worker");
+    logger.warn("⚠️ Redis not available for notification worker");
   }
 } else {
-  console.info("ℹ️ Notification worker disabled in development mode");
+  logger.info("ℹ️ Notification worker disabled in development mode");
 }
 
 export { notificationWorker };

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { error } from "../utils/responseWrapper";
 import { captureError } from "../telemetry/sentry"; // already used in your controllers
+import { logger } from "../utils/logger";
 
 export const globalErrorHandler = (
   err: any,
@@ -8,7 +9,7 @@ export const globalErrorHandler = (
   res: Response,
   next: NextFunction
 ) => {
-  console.error("🔥 Unhandled Error:", err);
+  logger.error("🔥 Unhandled Error:", err);
 
   // Send to Sentry or monitoring
   captureError(err, req.originalUrl);

--- a/src/middlewares/globalRateLimiter.ts
+++ b/src/middlewares/globalRateLimiter.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { createClient } from "redis";
 import { error } from "../utils/responseWrapper";
 import { isProduction } from "../config/env";
+import { logger } from "../utils/logger";
 
 // In-memory rate limiting fallback
 const memoryStore = new Map<string, { count: number; resetTime: number }>();
@@ -13,12 +14,12 @@ if (isProduction) {
     redis = createClient({ url: process.env.REDIS_URL });
     redis.connect();
   } catch (error) {
-    console.warn(
+    logger.warn(
       "⚠️ Redis not available for rate limiting, using memory store"
     );
   }
 } else {
-  console.info("ℹ️ Redis disabled for rate limiting in local development");
+  logger.info("ℹ️ Redis disabled for rate limiting in local development");
 }
 
 // ⏱ Route-specific limits
@@ -87,7 +88,7 @@ export const globalRateLimiter = async (
 
     next();
   } catch (error) {
-    console.error("❌ RateLimiter error:", error);
+    logger.error("❌ RateLimiter error:", error);
     // Continue without rate limiting if there's an error
     next();
   }

--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { createClient } from "redis";
 import { error } from "../utils/responseWrapper";
 import { isProduction } from "../config/env";
+import { logger } from "../utils/logger";
 
 // In-memory rate limiting fallback
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
@@ -13,12 +14,12 @@ if (isProduction) {
     redis = createClient({ url: process.env.REDIS_URL });
     redis.connect();
   } catch (error) {
-    console.warn(
+    logger.warn(
       "⚠️ Redis not available for rate limiting, using memory store"
     );
   }
 } else {
-  console.info("ℹ️ Redis disabled for rate limiting in local development");
+  logger.info("ℹ️ Redis disabled for rate limiting in local development");
 }
 
 export const rateLimiter = ({
@@ -66,7 +67,7 @@ export const rateLimiter = ({
 
       next();
     } catch (error) {
-      console.error("Rate limiter error:", error);
+      logger.error("Rate limiter error:", error);
       // Continue without rate limiting if there's an error
       next();
     }

--- a/src/middlewares/requestLogger.ts
+++ b/src/middlewares/requestLogger.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import { logger } from "../utils/logger";
 
 export const requestLogger = (
   req: Request,
@@ -22,7 +23,7 @@ export const requestLogger = (
     const url = req.originalUrl;
     const status = res.statusCode;
 
-    console.log(`[${label}] ${method} ${url} - ${status} - ${duration}ms`);
+    logger.info(`[${label}] ${method} ${url} - ${status} - ${duration}ms`);
   });
 
   next();

--- a/src/routes/user/init.controller.ts
+++ b/src/routes/user/init.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { formatInitAppResponse } from "../../resources/user/init.resource";
 import { success, error } from "../../utils/responseWrapper";
+import { logger } from "../../utils/logger";
 
 const prisma = new PrismaClient();
 
@@ -19,7 +20,7 @@ export const initApp = async (req: Request, res: Response) => {
 
     return res.json(success("App settings fetched", formatInitAppResponse(setting)));
   } catch (err) {
-    console.error("InitApp Error:", err);
+    logger.error("InitApp Error:", err);
     return res.status(500).json(error("Server error"));
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ export const startServer = async () => {
   // Middleware
   app.use((req, res, next) => {
     if (typeof res.setHeader !== "function") {
-      console.error("res.setHeader is not a function!", res);
+      logger.error("res.setHeader is not a function!", res);
       return res.status(500).json(error("res.setHeader is not a function"));
     }
     next();

--- a/src/telemetry/sentry.ts
+++ b/src/telemetry/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { isProduction } from "../config/env";
+import { logger } from "../utils/logger";
 
 export const initSentry = () => {
   if (!isProduction) return;
@@ -10,6 +11,6 @@ export const initSentry = () => {
 };
 
 export const captureError = (error: any, context?: string) => {
-  console.error(`[ERROR] ${context}:`, error);
+  logger.error(`[ERROR] ${context}:`, error);
   Sentry.captureException(error);
 };

--- a/src/utils/testSetup.ts
+++ b/src/utils/testSetup.ts
@@ -5,6 +5,7 @@ import { PrismaClient } from "@prisma/client";
 import RedisStore from "connect-redis";
 import { createClient } from "redis";
 import { isProduction } from "../config/env";
+import { logger } from "./logger";
 // Use user routes for testing APIs
 import router from "../api/user.routes";
 
@@ -18,10 +19,10 @@ if (isProduction) {
     redisClient = createClient();
     RedisSession = (RedisStore as any)(session);
   } catch (error) {
-    console.warn("⚠️ Redis not available for test setup");
+    logger.warn("⚠️ Redis not available for test setup");
   }
 } else {
-  console.info("ℹ️ Redis disabled for test setup in development");
+  logger.info("ℹ️ Redis disabled for test setup in development");
 }
 
 export const app = express();


### PR DESCRIPTION
## Summary
- remove real credentials from `.env`
- use common logger instead of direct `console` statements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687538027d5c832481cd39e0a7b7e868