### PR TITLE
Organize API routes under versioned paths

### DIFF
--- a/postman_user_admin_collection.json
+++ b/postman_user_admin_collection.json
@@ -50,9 +50,9 @@
                   "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\",\n  \"password\": \"secret123\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/auth/register",
+                  "raw": "{{base_url}}/api/user/auth/register",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "register"]
+                  "path": ["api", "user", "auth", "register"]
                 }
               }
             },
@@ -68,9 +68,9 @@
                   "raw": "{\n  \"email\": \"john@example.com\",\n  \"password\": \"secret123\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/auth/login",
+                  "raw": "{{base_url}}/api/user/auth/login",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "login"]
+                  "path": ["api", "user", "auth", "login"]
                 }
               },
               "event": [
@@ -98,9 +98,9 @@
                   "raw": "{\n  \"provider\": \"google\",\n  \"token\": \"<token>\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/auth/social-login",
+                  "raw": "{{base_url}}/api/user/auth/social-login",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "social-login"]
+                  "path": ["api", "user", "auth", "social-login"]
                 }
               }
             },
@@ -110,9 +110,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/api/auth/apple-details/:id",
+                  "raw": "{{base_url}}/api/user/auth/apple-details/:id",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "apple-details", ":id"]
+                  "path": ["api", "user", "auth", "apple-details", ":id"]
                 }
               }
             },
@@ -128,9 +128,9 @@
                   "raw": "{\n  \"email\": \"john@example.com\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/auth/send/otp",
+                  "raw": "{{base_url}}/api/user/auth/send/otp",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "send", "otp"]
+                  "path": ["api", "user", "auth", "send", "otp"]
                 }
               }
             },
@@ -146,9 +146,9 @@
                   "raw": "{\n  \"email\": \"john@example.com\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/auth/forgot/password",
+                  "raw": "{{base_url}}/api/user/auth/forgot/password",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "auth", "forgot", "password"]
+                  "path": ["api", "user", "auth", "forgot", "password"]
                 }
               }
             },
@@ -289,9 +289,9 @@
                   "raw": "{\n  \"email\": \"admin@example.com\",\n  \"password\": \"adminpass\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/admin/login",
+                  "raw": "{{base_url}}/api/admin/auth/login",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "login"]
+                  "path": ["api", "admin", "auth", "login"]
                 }
               },
               "event": [
@@ -490,9 +490,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/api/admin/users",
+                  "raw": "{{base_url}}/api/admin/user/users",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "users"]
+                  "path": ["api", "admin", "user", "users"]
                 }
               }
             },
@@ -508,9 +508,9 @@
                   "raw": "{\n  \"name\": \"John Doe\"\n}"
                 },
                 "url": {
-                  "raw": "{{base_url}}/api/admin/users/:id/update",
+                  "raw": "{{base_url}}/api/admin/user/users/:id/update",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "users", ":id", "update"]
+                  "path": ["api", "admin", "user", "users", ":id", "update"]
                 }
               }
             },
@@ -520,9 +520,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/api/admin/users/:id/toggle",
+                  "raw": "{{base_url}}/api/admin/user/users/:id/toggle",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "users", ":id", "toggle"]
+                  "path": ["api", "admin", "user", "users", ":id", "toggle"]
                 }
               }
             },
@@ -532,9 +532,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/api/admin/users/:id/delete",
+                  "raw": "{{base_url}}/api/admin/user/users/:id/delete",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "users", ":id", "delete"]
+                  "path": ["api", "admin", "user", "users", ":id", "delete"]
                 }
               }
             }
@@ -549,9 +549,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/api/admin/export/users/:type",
+                  "raw": "{{base_url}}/api/admin/user/export/users/:type",
                   "host": ["{{base_url}}"],
-                  "path": ["api", "admin", "export", "users", ":type"]
+                  "path": ["api", "admin", "user", "export", "users", ":type"]
                 }
               }
             }

--- a/src/api/admin.routes.ts
+++ b/src/api/admin.routes.ts
@@ -9,13 +9,13 @@ import exportRoutes from "../routes/admin/export";
 
 const router = Router();
 
-router.use("/", authRoutes);
+router.use("/auth", authRoutes);
 router.use("/", profileRoutes);
 router.use("/", appSettingRoutes);
 router.use("/", appLinkRoutes);
 router.use("/", appVariableRoutes);
-router.use("/", userRoutes);
-router.use("/", exportRoutes);
+router.use("/user", userRoutes);
+router.use("/user", exportRoutes);
 
 
 

--- a/src/routes/user/notification.ts
+++ b/src/routes/user/notification.ts
@@ -10,13 +10,13 @@ import { clearAllNotifications } from "./notification.controller";
 const router = Router();
 
 router.get(
-  "/user/notifications",
+  "/notifications",
   logRoute("USER_NOTIFICATIONS"),
   requireUserAuth,
   getNotifications
 );
 router.get(
-  "/user/notifications/status/change/:status",
+  "/notifications/status/change/:status",
   logRoute("NOTIF_STATUS_CHANGE"),
   requireUserAuth,
   validateRequest({ params: NotificationStatusParamSchema }),
@@ -24,7 +24,7 @@ router.get(
 );
 
 router.get(
-  "/user/notifications/clear-all",
+  "/notifications/clear-all",
   logRoute("NOTIF_CLEAR_ALL"),
   requireUserAuth,
   clearAllNotifications

--- a/src/routes/user/password.ts
+++ b/src/routes/user/password.ts
@@ -12,7 +12,7 @@ import { logRoute } from "../../decorators/logRoute";
 const router = Router();
 
 router.post(
-  "/user/change/password",
+  "/change/password",
   logRoute("CHANGE_PASSWORD"),
   requireUserAuth,
   validateRequest({ body: ChangePasswordRequestSchema }),

--- a/src/routes/user/profile.ts
+++ b/src/routes/user/profile.ts
@@ -8,9 +8,9 @@ import { updateProfile } from "./profile.controller";
 
 const router = Router();
 
-router.get("/user/me", logRoute("USER_ME"), requireUserAuth, getProfile);
+router.get("/me", logRoute("USER_ME"), requireUserAuth, getProfile);
 router.post(
-  "/user/update",
+  "/update",
   logRoute("USER_UPDATE"),
   requireUserAuth,
   validateRequest({ body: UpdateProfileRequestSchema }),

--- a/src/routes/user/session.ts
+++ b/src/routes/user/session.ts
@@ -5,6 +5,6 @@ import { logRoute } from "../../decorators/logRoute";
 
 const router = Router();
 
-router.get("/user/logout", logRoute("LOGOUT"), requireUserAuth, logout);
+router.get("/logout", logRoute("LOGOUT"), requireUserAuth, logout);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,7 +86,7 @@ export const startServer = async (): Promise<Server> => {
   app.use("/api/health", healthRoutes);
 
   // User routes
-  app.use("/api", userRoutes);
+  app.use("/api/user", userRoutes);
   app.use("/api/admin", adminRoutes);
   // app.use("/api/docs", docsRoutes);
   // app.use("/api/admin/queues", bullBoardRoutes);

--- a/tests/helpers/expressAuthTestHelper.ts
+++ b/tests/helpers/expressAuthTestHelper.ts
@@ -6,7 +6,11 @@ export interface AuthTestServer {
   request: SuperTest<Test>;
 }
 
-export const createAuthTestServer = (router: Router, authenticated = true): AuthTestServer => {
+export const createAuthTestServer = (
+  router: Router,
+  authenticated = true,
+  basePath = '/'
+): AuthTestServer => {
   const app = express();
   app.use(express.json());
   if (authenticated) {
@@ -15,6 +19,6 @@ export const createAuthTestServer = (router: Router, authenticated = true): Auth
       next();
     });
   }
-  app.use('/', router);
+  app.use(basePath, router);
   return { app, request: request(app) };
 };

--- a/tests/helpers/expressTestHelper.ts
+++ b/tests/helpers/expressTestHelper.ts
@@ -6,10 +6,13 @@ export interface TestServer {
   request: SuperTest<Test>;
 }
 
-export const createTestServer = (router: Router): TestServer => {
+export const createTestServer = (
+  router: Router,
+  basePath = '/'
+): TestServer => {
   const app = express();
   app.use(express.json());
-  app.use('/', router);
+  app.use(basePath, router);
   return { app, request: request(app) };
 };
 

--- a/tests/routes/authRoutes.test.ts
+++ b/tests/routes/authRoutes.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 });
 
 describe('Auth Routes', () => {
-  describe('POST /auth/register', () => {
+  describe('POST /api/user/auth/register', () => {
     it('should register a new user', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce(null);
       (hashUtils.hashPassword as jest.Mock).mockResolvedValueOnce('hashed');
@@ -33,7 +33,7 @@ describe('Auth Routes', () => {
         email: 'john@example.com',
       });
 
-      const res = await server.request.post('/auth/register').send({
+      const res = await server.request.post('/api/user/auth/register').send({
         name: 'John',
         email: 'john@example.com',
         password: 'secret123',
@@ -46,7 +46,7 @@ describe('Auth Routes', () => {
     it('should return 409 if email exists', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce({ id: 1 });
 
-      const res = await server.request.post('/auth/register').send({
+      const res = await server.request.post('/api/user/auth/register').send({
         name: 'John',
         email: 'john@example.com',
         password: 'secret123',
@@ -56,7 +56,7 @@ describe('Auth Routes', () => {
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/auth/register').send({
+      const res = await server.request.post('/api/user/auth/register').send({
         name: 'J',
         email: 'bad',
         password: '1',
@@ -68,7 +68,7 @@ describe('Auth Routes', () => {
     it('should handle server errors', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockRejectedValueOnce(new Error('db error'));
 
-      const res = await server.request.post('/auth/register').send({
+      const res = await server.request.post('/api/user/auth/register').send({
         name: 'John',
         email: 'john@example.com',
         password: 'secret123',
@@ -78,7 +78,7 @@ describe('Auth Routes', () => {
     });
   });
 
-  describe('POST /auth/login', () => {
+  describe('POST /api/user/auth/login', () => {
     it('should login successfully', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce({
         id: 1,
@@ -88,7 +88,7 @@ describe('Auth Routes', () => {
       });
       (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(true);
 
-      const res = await server.request.post('/auth/login').send({
+      const res = await server.request.post('/api/user/auth/login').send({
         email: 'john@example.com',
         password: 'secret123',
       });
@@ -100,7 +100,7 @@ describe('Auth Routes', () => {
     it('should return 404 if user not found', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce(null);
 
-      const res = await server.request.post('/auth/login').send({
+      const res = await server.request.post('/api/user/auth/login').send({
         email: 'john@example.com',
         password: 'secret123',
       });
@@ -117,7 +117,7 @@ describe('Auth Routes', () => {
       });
       (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(false);
 
-      const res = await server.request.post('/auth/login').send({
+      const res = await server.request.post('/api/user/auth/login').send({
         email: 'john@example.com',
         password: 'secret123',
       });
@@ -126,7 +126,7 @@ describe('Auth Routes', () => {
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/auth/login').send({
+      const res = await server.request.post('/api/user/auth/login').send({
         email: 'bad',
         password: '1',
       });
@@ -137,7 +137,7 @@ describe('Auth Routes', () => {
     it('should handle server errors', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockRejectedValueOnce(new Error('db error'));
 
-      const res = await server.request.post('/auth/login').send({
+      const res = await server.request.post('/api/user/auth/login').send({
         email: 'john@example.com',
         password: 'secret123',
       });
@@ -146,9 +146,9 @@ describe('Auth Routes', () => {
     });
   });
 
-  describe('POST /auth/social-login', () => {
+  describe('POST /api/user/auth/social-login', () => {
     it('should return 400 as not supported', async () => {
-      const res = await server.request.post('/auth/social-login').send({
+      const res = await server.request.post('/api/user/auth/social-login').send({
         social_id: 'abc',
         provider: 'google',
         name: 'John',
@@ -158,7 +158,7 @@ describe('Auth Routes', () => {
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/auth/social-login').send({
+      const res = await server.request.post('/api/user/auth/social-login').send({
         social_id: '',
         provider: 'google',
         name: 'John',
@@ -169,78 +169,78 @@ describe('Auth Routes', () => {
     it('should handle server errors', async () => {
       (logAppleCheck as jest.Mock).mockImplementationOnce(() => { throw new Error('fail'); });
       // call apple route to trigger catch; social-login has no dep to throw
-      const res = await server.request.get('/auth/apple-details/abc');
+      const res = await server.request.get('/api/user/auth/apple-details/abc');
       expect(res.status).toBe(500);
     });
   });
 
-  describe('GET /auth/apple-details/:id', () => {
+  describe('GET /api/user/auth/apple-details/:id', () => {
     it('should return 400 as feature not supported', async () => {
-      const res = await server.request.get('/auth/apple-details/abc');
+      const res = await server.request.get('/api/user/auth/apple-details/abc');
       expect(res.status).toBe(400);
     });
 
     it('should return 422 for invalid params', async () => {
-      const res = await server.request.get('/auth/apple-details/ab');
+      const res = await server.request.get('/api/user/auth/apple-details/ab');
       expect(res.status).toBe(422);
     });
 
     it('should handle server errors', async () => {
       (logAppleCheck as jest.Mock).mockImplementationOnce(() => { throw new Error('fail'); });
-      const res = await server.request.get('/auth/apple-details/abc');
+      const res = await server.request.get('/api/user/auth/apple-details/abc');
       expect(res.status).toBe(500);
     });
   });
 
-  describe('POST /auth/send/otp', () => {
+  describe('POST /api/user/auth/send/otp', () => {
     it('should send otp', async () => {
       (otpUtils.generateOtp as jest.Mock).mockReturnValueOnce('123456');
-      const res = await server.request.post('/auth/send/otp').send({ email: 'john@example.com' });
+      const res = await server.request.post('/api/user/auth/send/otp').send({ email: 'john@example.com' });
       expect(res.status).toBe(200);
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/auth/send/otp').send({ email: 'bad' });
+      const res = await server.request.post('/api/user/auth/send/otp').send({ email: 'bad' });
       expect(res.status).toBe(422);
     });
 
     it('should handle server errors', async () => {
       (otpUtils.saveOtpToRedis as jest.Mock).mockRejectedValueOnce(new Error('redis error'));
-      const res = await server.request.post('/auth/send/otp').send({ email: 'john@example.com' });
+      const res = await server.request.post('/api/user/auth/send/otp').send({ email: 'john@example.com' });
       expect(res.status).toBe(500);
     });
   });
 
-  describe('POST /auth/forgot/password', () => {
+  describe('POST /api/user/auth/forgot/password', () => {
     it('should send reset link', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce({ id: 1, email: 'john@example.com' });
       (resetTokenUtils.generateResetToken as jest.Mock).mockResolvedValueOnce('token');
 
-      const res = await server.request.post('/auth/forgot/password').send({ email: 'john@example.com' });
+      const res = await server.request.post('/api/user/auth/forgot/password').send({ email: 'john@example.com' });
       expect(res.status).toBe(200);
       expect(res.body.resetUrl).toBeDefined();
     });
 
     it('should return 404 when email not found', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce(null);
-      const res = await server.request.post('/auth/forgot/password').send({ email: 'john@example.com' });
+      const res = await server.request.post('/api/user/auth/forgot/password').send({ email: 'john@example.com' });
       expect(res.status).toBe(404);
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/auth/forgot/password').send({ email: 'bad' });
+      const res = await server.request.post('/api/user/auth/forgot/password').send({ email: 'bad' });
       expect(res.status).toBe(422);
     });
 
     it('should handle server errors', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockRejectedValueOnce(new Error('db error'));
-      const res = await server.request.post('/auth/forgot/password').send({ email: 'john@example.com' });
+      const res = await server.request.post('/api/user/auth/forgot/password').send({ email: 'john@example.com' });
       expect(res.status).toBe(500);
     });
   });
 
   it('should return 404 for unknown route', async () => {
-    const res = await server.request.get('/unknown');
+    const res = await server.request.get('/api/user/unknown');
     expect(res.status).toBe(404);
   });
 });

--- a/tests/routes/initRoutes.test.ts
+++ b/tests/routes/initRoutes.test.ts
@@ -15,7 +15,7 @@ import initRoutes from '../../src/routes/user/init';
 let server: TestServer;
 
 beforeAll(() => {
-  server = createTestServer(initRoutes);
+  server = createTestServer(initRoutes, '/api/user');
 });
 
 describe('Init Routes', () => {
@@ -33,7 +33,7 @@ describe('Init Routes', () => {
     };
     mockFindFirst.mockResolvedValueOnce(mockSetting);
 
-    const res = await server.request.get('/init/1.0.0/android');
+    const res = await server.request.get('/api/user/init/1.0.0/android');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       app_type: 'android',
@@ -47,18 +47,18 @@ describe('Init Routes', () => {
   it('should return 404 when no setting found', async () => {
     mockFindFirst.mockResolvedValueOnce(null);
 
-    const res = await server.request.get('/init/1.0.0/android');
+    const res = await server.request.get('/api/user/init/1.0.0/android');
     expect(res.statusCode).toBe(404);
   });
 
   it('should return 422 for invalid params', async () => {
-    const res = await server.request.get('/init/bad-version/android');
+    const res = await server.request.get('/api/user/init/bad-version/android');
     expect(res.statusCode).toBe(422);
   });
 
   it('should handle server errors', async () => {
     mockFindFirst.mockRejectedValueOnce(new Error('db error'));
-    const res = await server.request.get('/init/1.0.0/android');
+    const res = await server.request.get('/api/user/init/1.0.0/android');
     expect(res.statusCode).toBe(500);
   });
 });

--- a/tests/routes/notificationRoutes.test.ts
+++ b/tests/routes/notificationRoutes.test.ts
@@ -9,7 +9,7 @@ jest.mock('../../src/jobs/notification.jobs');
 let server: AuthTestServer;
 
 beforeAll(() => {
-  server = createAuthTestServer(notificationRoutes);
+  server = createAuthTestServer(notificationRoutes, true, '/api/user');
 });
 
 beforeEach(() => {
@@ -17,55 +17,55 @@ beforeEach(() => {
 });
 
 describe('Notification Routes', () => {
-  describe('GET /user/notifications', () => {
+  describe('GET /api/user/notifications', () => {
     it('should return notifications', async () => {
       (notifRepo.findUserNotifications as jest.Mock).mockResolvedValueOnce([]);
-      const res = await server.request.get('/user/notifications');
+      const res = await server.request.get('/api/user/notifications');
       expect(res.status).toBe(200);
     });
 
     it('should return 401 without session', async () => {
-      const unauth = createAuthTestServer(notificationRoutes, false);
-      const res = await unauth.request.get('/user/notifications');
+      const unauth = createAuthTestServer(notificationRoutes, false, '/api/user');
+      const res = await unauth.request.get('/api/user/notifications');
       expect(res.status).toBe(401);
     });
 
     it('should handle server errors', async () => {
       (notifRepo.findUserNotifications as jest.Mock).mockRejectedValueOnce(new Error('fail'));
-      const res = await server.request.get('/user/notifications');
+      const res = await server.request.get('/api/user/notifications');
       expect(res.status).toBe(500);
     });
   });
 
-  describe('GET /user/notifications/status/change/:status', () => {
+  describe('GET /api/user/notifications/status/change/:status', () => {
     it('should update notification status', async () => {
       (notifRepo.updateUserNotificationStatus as jest.Mock).mockResolvedValueOnce(1);
-      const res = await server.request.get('/user/notifications/status/change/read');
+      const res = await server.request.get('/api/user/notifications/status/change/read');
       expect(res.status).toBe(200);
     });
 
     it('should return 422 for invalid param', async () => {
-      const res = await server.request.get('/user/notifications/status/change/bad');
+      const res = await server.request.get('/api/user/notifications/status/change/bad');
       expect(res.status).toBe(422);
     });
 
     it('should handle server errors', async () => {
       (notifRepo.updateUserNotificationStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
-      const res = await server.request.get('/user/notifications/status/change/read');
+      const res = await server.request.get('/api/user/notifications/status/change/read');
       expect(res.status).toBe(500);
     });
   });
 
-  describe('GET /user/notifications/clear-all', () => {
+  describe('GET /api/user/notifications/clear-all', () => {
     it('should clear notifications', async () => {
       (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockResolvedValueOnce(3);
-      const res = await server.request.get('/user/notifications/clear-all');
+      const res = await server.request.get('/api/user/notifications/clear-all');
       expect(res.status).toBe(200);
     });
 
     it('should handle server errors', async () => {
       (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
-      const res = await server.request.get('/user/notifications/clear-all');
+      const res = await server.request.get('/api/user/notifications/clear-all');
       expect(res.status).toBe(500);
     });
   });

--- a/tests/routes/profileRoutes.test.ts
+++ b/tests/routes/profileRoutes.test.ts
@@ -7,7 +7,7 @@ jest.mock('../../src/repositories/user.repository');
 let server: AuthTestServer;
 
 beforeAll(() => {
-  server = createAuthTestServer(profileRoutes);
+  server = createAuthTestServer(profileRoutes, true, '/api/user');
 });
 
 beforeEach(() => {
@@ -15,47 +15,47 @@ beforeEach(() => {
 });
 
 describe('Profile Routes', () => {
-  describe('GET /user/me', () => {
+  describe('GET /api/user/me', () => {
     it('should return profile for authenticated user', async () => {
       (userRepo.findUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
-      const res = await server.request.get('/user/me');
+      const res = await server.request.get('/api/user/me');
       expect(res.status).toBe(200);
     });
 
     it('should return 404 when user not found', async () => {
       (userRepo.findUserById as jest.Mock).mockResolvedValueOnce(null);
-      const res = await server.request.get('/user/me');
+      const res = await server.request.get('/api/user/me');
       expect(res.status).toBe(404);
     });
 
     it('should return 401 without session', async () => {
-      const unauth = createAuthTestServer(profileRoutes, false);
-      const res = await unauth.request.get('/user/me');
+      const unauth = createAuthTestServer(profileRoutes, false, '/api/user');
+      const res = await unauth.request.get('/api/user/me');
       expect(res.status).toBe(401);
     });
 
     it('should handle server errors', async () => {
       (userRepo.findUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
-      const res = await server.request.get('/user/me');
+      const res = await server.request.get('/api/user/me');
       expect(res.status).toBe(500);
     });
   });
 
-  describe('POST /user/update', () => {
+  describe('POST /api/user/update', () => {
     it('should update user profile', async () => {
       (userRepo.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
-      const res = await server.request.post('/user/update').send({ name: 'John', email: 'john@example.com' });
+      const res = await server.request.post('/api/user/update').send({ name: 'John', email: 'john@example.com' });
       expect(res.status).toBe(200);
     });
 
     it('should return 422 for invalid payload', async () => {
-      const res = await server.request.post('/user/update').send({ name: 'J', email: 'bad' });
+      const res = await server.request.post('/api/user/update').send({ name: 'J', email: 'bad' });
       expect(res.status).toBe(422);
     });
 
     it('should handle server errors', async () => {
       (userRepo.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
-      const res = await server.request.post('/user/update').send({ name: 'John', email: 'john@example.com' });
+      const res = await server.request.post('/api/user/update').send({ name: 'John', email: 'john@example.com' });
       expect(res.status).toBe(500);
     });
   });

--- a/tests/routes/sessionRoutes.test.ts
+++ b/tests/routes/sessionRoutes.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../src/jobs/session.jobs');
 let server: AuthTestServer;
 
 beforeAll(() => {
-  server = createAuthTestServer(sessionRoutes);
+  server = createAuthTestServer(sessionRoutes, true, '/api/user');
 });
 
 beforeEach(() => {
@@ -19,21 +19,21 @@ beforeEach(() => {
 });
 
 describe('Session Routes', () => {
-  describe('GET /user/logout', () => {
+  describe('GET /api/user/logout', () => {
     it('should logout successfully', async () => {
-      const res = await server.request.get('/user/logout');
+      const res = await server.request.get('/api/user/logout');
       expect(res.status).toBe(200);
     });
 
     it('should return 401 without session', async () => {
-      const unauth = createAuthTestServer(sessionRoutes, false);
-      const res = await unauth.request.get('/user/logout');
+      const unauth = createAuthTestServer(sessionRoutes, false, '/api/user');
+      const res = await unauth.request.get('/api/user/logout');
       expect(res.status).toBe(401);
     });
 
     it('should handle server errors', async () => {
       (sessionUtils.destroySession as jest.Mock).mockRejectedValueOnce(new Error('fail'));
-      const res = await server.request.get('/user/logout');
+      const res = await server.request.get('/api/user/logout');
       expect(res.status).toBe(500);
     });
   });

--- a/tests/routes/userRoutes.test.ts
+++ b/tests/routes/userRoutes.test.ts
@@ -9,7 +9,7 @@ jest.mock('../../src/repositories/notification.repository');
 let server: AuthTestServer;
 
 beforeAll(() => {
-  server = createAuthTestServer(userRoutes);
+  server = createAuthTestServer(userRoutes, true, '/api/user');
 });
 
 beforeEach(() => {
@@ -23,20 +23,20 @@ beforeEach(() => {
 });
 
 describe('User Router', () => {
-  it('should mount /auth routes', async () => {
-    const res = await server.request.post('/auth/login').send({ email: 'a@b.com', password: 'secret123' });
+  it('should mount /api/user/auth routes', async () => {
+    const res = await server.request.post('/api/user/auth/login').send({ email: 'a@b.com', password: 'secret123' });
     expect(res.status).not.toBe(404);
   });
 
   it('should mount /user/me route', async () => {
     (userRepo.findUserById as jest.Mock).mockResolvedValueOnce({ id:1, name:'J', email:'a@b.com' });
-    const res = await server.request.get('/user/me');
+    const res = await server.request.get('/api/user/me');
     expect(res.status).not.toBe(404);
   });
 
   it('should mount notification routes', async () => {
     (notifRepo.findUserNotifications as jest.Mock).mockResolvedValueOnce([]);
-    const res = await server.request.get('/user/notifications');
+    const res = await server.request.get('/api/user/notifications');
     expect(res.status).not.toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- namespace user routes under `/api/user`
- add `/auth` and `/user` subpaths for admin API
- update tests for new base paths
- revise Postman collection accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753e27f5b4832484eaf699c3f70042