### PR TITLE
Add admin API tests

### DIFF
--- a/tests/helpers/expressAuthTestHelper.ts
+++ b/tests/helpers/expressAuthTestHelper.ts
@@ -9,13 +9,14 @@ export interface AuthTestServer {
 export const createAuthTestServer = (
   router: Router,
   authenticated = true,
-  basePath = '/'
+  basePath = '/',
+  role: 'user' | 'admin' = 'user'
 ): AuthTestServer => {
   const app = express();
   app.use(express.json());
   if (authenticated) {
     app.use((req, _res, next) => {
-      (req as any).session = { user: { id: 1, role: 'user' } };
+      (req as any).session = { user: { id: 1, role } };
       next();
     });
   }

--- a/tests/routes/adminAuthRoutes.test.ts
+++ b/tests/routes/adminAuthRoutes.test.ts
@@ -1,0 +1,81 @@
+import { createTestServer, TestServer } from '../helpers/expressTestHelper';
+import adminAuthRoutes from '../../src/routes/admin/auth';
+import * as adminRepo from '../../src/repositories/admin.repository';
+import * as hashUtils from '../../src/utils/hash';
+import * as sessionUtils from '../../src/utils/session';
+
+jest.mock('../../src/repositories/admin.repository');
+jest.mock('../../src/utils/hash');
+jest.mock('../../src/utils/session');
+
+let server: TestServer;
+
+beforeAll(() => {
+  server = createTestServer(adminAuthRoutes, '/api/admin/auth');
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Admin Auth Routes', () => {
+  describe('POST /api/admin/auth/login', () => {
+    it('should login admin successfully', async () => {
+      (adminRepo.findAdminByEmail as jest.Mock).mockResolvedValueOnce({
+        id: 1,
+        name: 'Admin',
+        email: 'admin@example.com',
+        password: 'hashed',
+      });
+      (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(true);
+      (sessionUtils.generateSession as jest.Mock).mockResolvedValueOnce(null);
+      const res = await server.request.post('/api/admin/auth/login').send({
+        email: 'admin@example.com',
+        password: 'secret123',
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Login successful');
+    });
+
+    it('should return 404 when admin not found', async () => {
+      (adminRepo.findAdminByEmail as jest.Mock).mockResolvedValueOnce(null);
+      const res = await server.request.post('/api/admin/auth/login').send({
+        email: 'admin@example.com',
+        password: 'secret123',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 401 for invalid password', async () => {
+      (adminRepo.findAdminByEmail as jest.Mock).mockResolvedValueOnce({
+        id: 1,
+        name: 'Admin',
+        email: 'admin@example.com',
+        password: 'hashed',
+      });
+      (hashUtils.comparePassword as jest.Mock).mockResolvedValueOnce(false);
+      const res = await server.request.post('/api/admin/auth/login').send({
+        email: 'admin@example.com',
+        password: 'wrong',
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 422 for invalid payload', async () => {
+      const res = await server.request.post('/api/admin/auth/login').send({
+        email: 'bad',
+        password: '1',
+      });
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (adminRepo.findAdminByEmail as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.post('/api/admin/auth/login').send({
+        email: 'admin@example.com',
+        password: 'secret123',
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/adminExportRoutes.test.ts
+++ b/tests/routes/adminExportRoutes.test.ts
@@ -1,0 +1,45 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import exportRoutes from '../../src/routes/admin/export';
+import * as userRepo from '../../src/repositories/user.repository';
+import * as exportJobs from '../../src/jobs/export.jobs';
+import XLSX from 'xlsx';
+
+jest.mock('../../src/repositories/user.repository');
+jest.mock('../../src/jobs/export.jobs');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(exportRoutes, true, '/api/admin/user', 'admin');
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Admin Export Routes', () => {
+  describe('GET /api/admin/user/export/users/:type', () => {
+    it('should export users in csv', async () => {
+      (userRepo.getAllUsersForExport as jest.Mock).mockResolvedValueOnce([]);
+      const res = await server.request.get('/api/admin/user/export/users/csv');
+      expect(res.status).toBe(200);
+    });
+
+    it('should export users in xlsx', async () => {
+      (userRepo.getAllUsersForExport as jest.Mock).mockResolvedValueOnce([]);
+      const res = await server.request.get('/api/admin/user/export/users/xlsx');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 400 for unsupported type', async () => {
+      const res = await server.request.get('/api/admin/user/export/users/pdf');
+      expect(res.status).toBe(400);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.getAllUsersForExport as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/api/admin/user/export/users/csv');
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/adminProfileRoutes.test.ts
+++ b/tests/routes/adminProfileRoutes.test.ts
@@ -1,0 +1,43 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import adminProfileRoutes from '../../src/routes/admin/profile';
+import * as adminRepo from '../../src/repositories/admin.repository';
+
+jest.mock('../../src/repositories/admin.repository');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(adminProfileRoutes, true, '/api/admin', 'admin');
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Admin Profile Routes', () => {
+  describe('GET /api/admin/me', () => {
+    it('should return admin profile', async () => {
+      (adminRepo.findAdminById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'Admin', email: 'a@b.com' });
+      const res = await server.request.get('/api/admin/me');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 404 when admin not found', async () => {
+      (adminRepo.findAdminById as jest.Mock).mockResolvedValueOnce(null);
+      const res = await server.request.get('/api/admin/me');
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 401 without session', async () => {
+      const unauth = createAuthTestServer(adminProfileRoutes, false, '/api/admin', 'admin');
+      const res = await unauth.request.get('/api/admin/me');
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (adminRepo.findAdminById as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/api/admin/me');
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/tests/routes/adminUserRoutes.test.ts
+++ b/tests/routes/adminUserRoutes.test.ts
@@ -1,0 +1,100 @@
+import { createAuthTestServer, AuthTestServer } from '../helpers/expressAuthTestHelper';
+import adminUserRoutes from '../../src/routes/admin/user';
+import * as userRepo from '../../src/repositories/user.repository';
+
+jest.mock('../../src/repositories/user.repository');
+
+let server: AuthTestServer;
+
+beforeAll(() => {
+  server = createAuthTestServer(adminUserRoutes, true, '/api/admin/user', 'admin');
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Admin User Routes', () => {
+  describe('GET /api/admin/user/users', () => {
+    it('should list users', async () => {
+      (userRepo.getAllUsers as jest.Mock).mockResolvedValueOnce([]);
+      const res = await server.request.get('/api/admin/user/users');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 401 without admin auth', async () => {
+      const unauth = createAuthTestServer(adminUserRoutes, false, '/api/admin/user', 'admin');
+      const res = await unauth.request.get('/api/admin/user/users');
+      expect(res.status).toBe(401);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.getAllUsers as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/api/admin/user/users');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('POST /api/admin/user/users/:id/update', () => {
+    it('should update user', async () => {
+      (userRepo.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1 });
+      const res = await server.request
+        .post('/api/admin/user/users/1/update')
+        .send({ name: 'John' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid params', async () => {
+      const res = await server.request
+        .post('/api/admin/user/users/bad/update')
+        .send({ name: 'John' });
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request
+        .post('/api/admin/user/users/1/update')
+        .send({ name: 'John' });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /api/admin/user/users/:id/toggle', () => {
+    it('should toggle user status', async () => {
+      (userRepo.toggleUserStatus as jest.Mock).mockResolvedValueOnce({ id: 1, status: true });
+      const res = await server.request.get('/api/admin/user/users/1/toggle');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid id', async () => {
+      const res = await server.request.get('/api/admin/user/users/bad/toggle');
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.toggleUserStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/api/admin/user/users/1/toggle');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /api/admin/user/users/:id/delete', () => {
+    it('should delete user', async () => {
+      (userRepo.softDeleteUser as jest.Mock).mockResolvedValueOnce({ id: 1 });
+      const res = await server.request.get('/api/admin/user/users/1/delete');
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 422 for invalid id', async () => {
+      const res = await server.request.get('/api/admin/user/users/abc/delete');
+      expect(res.status).toBe(422);
+    });
+
+    it('should handle server errors', async () => {
+      (userRepo.softDeleteUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const res = await server.request.get('/api/admin/user/users/1/delete');
+      expect(res.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend `createAuthTestServer` to allow `admin` sessions
- add tests for admin login
- add tests for admin profile route
- add tests for admin user management routes
- add tests for admin export route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687542c89fc08324be280dbeec058154