### PR TITLE
Fix test paths and CSV export

### DIFF
--- a/src/routes/admin/export.controller.ts
+++ b/src/routes/admin/export.controller.ts
@@ -17,8 +17,7 @@ export const exportUsersHandler = async (req: Request, res: Response) => {
       .slice(0, 10)}.${type}`;
 
     if (type === "csv") {
-      const parser = new Parser();
-      const csv = parser.parse(users);
+      const csv = users.length ? new Parser().parse(users) : "";
       // res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
       // res.setHeader("Content-Type", "text/csv");
       logUserExport("csv");

--- a/tests/routes/authRoutes.test.ts
+++ b/tests/routes/authRoutes.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../src/jobs/logAppleCheck');
 let server: TestServer;
 
 beforeAll(() => {
-  server = createTestServer(authRoutes);
+  server = createTestServer(authRoutes, '/api/user');
 });
 
 beforeEach(() => {

--- a/tests/routes/passwordRoutes.test.ts
+++ b/tests/routes/passwordRoutes.test.ts
@@ -91,7 +91,7 @@ describe('Password Routes', () => {
       (resetTokenUtils.getUserIdFromToken as jest.Mock).mockResolvedValueOnce('1');
       (hashUtils.hashPassword as jest.Mock).mockResolvedValueOnce('hashed');
       const res = await unauth.request
-        .post('/api/user/reset-password/abc')
+        .post('/api/user/reset-password/00000000-0000-0000-0000-000000000000')
         .send({ new_password: 'newpass' });
       expect(res.status).toBe(200);
     });
@@ -100,7 +100,7 @@ describe('Password Routes', () => {
       const unauth = createAuthTestServer(passwordRoutes, false, '/api/user');
       (resetTokenUtils.getUserIdFromToken as jest.Mock).mockResolvedValueOnce(null);
       const res = await unauth.request
-        .post('/api/user/reset-password/bad')
+        .post('/api/user/reset-password/11111111-1111-1111-1111-111111111111')
         .send({ new_password: 'newpass' });
       expect(res.status).toBe(400);
     });
@@ -108,7 +108,7 @@ describe('Password Routes', () => {
     it('should return 422 for invalid payload', async () => {
       const unauth = createAuthTestServer(passwordRoutes, false, '/api/user');
       const res = await unauth.request
-        .post('/api/user/reset-password/abc')
+        .post('/api/user/reset-password/00000000-0000-0000-0000-000000000000')
         .send({ new_password: '1' });
       expect(res.status).toBe(422);
     });
@@ -117,7 +117,7 @@ describe('Password Routes', () => {
       const unauth = createAuthTestServer(passwordRoutes, false, '/api/user');
       (resetTokenUtils.getUserIdFromToken as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await unauth.request
-        .post('/api/user/reset-password/abc')
+        .post('/api/user/reset-password/00000000-0000-0000-0000-000000000000')
         .send({ new_password: 'newpass' });
       expect(res.status).toBe(500);
     });


### PR DESCRIPTION
## Summary
- fix `authRoutes` test server path
- use valid UUIDs in password reset tests
- return an empty CSV when no users are present

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: can't find type defs)*

------
https://chatgpt.com/codex/tasks/task_e_6875dd6962b883248db714c0e76f783b