### PR TITLE
Centralize 500 error handling

### DIFF
--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -14,10 +14,9 @@ export const globalErrorHandler = (
   // Send to Sentry or monitoring
   captureError(err, req.originalUrl);
 
-  return (
-    res
-      .status(500)
-      // .json(error("Internal server error. Please try again later."));
-      .json(error(err.message))
-  );
+  const message = err.stack
+    ? err.stack.split("\n").slice(0, 5).join("\n")
+    : err.message;
+
+  return res.status(500).json(error(message));
 };

--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -25,7 +25,7 @@ export default function validateRequest({
           .json(error("Validation failed", formatZodError(err)));
       }
 
-      return res.status(500).json(error("Unexpected validation error"));
+      return next(err);
     }
   };
 }

--- a/src/routes/admin/appLink.controller.ts
+++ b/src/routes/admin/appLink.controller.ts
@@ -1,16 +1,20 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { getAppLinks } from "../../repositories/appLink.repository";
 import { formatAppLinksList } from "../../resources/admin/appLink.resource";
 import { captureError } from "../../telemetry/sentry";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAppLinksHandler = async (req: Request, res: Response) => {
+export const getAppLinksHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const links = await getAppLinks();
     return res.json(success("Links fetched", formatAppLinksList(links)));
   } catch (err) {
     captureError(err, "getAppLinks");
-    return res.status(500).json(error("Failed to load app links"));
+    return next(err);
   }
 };
 
@@ -22,7 +26,11 @@ import { updateAppLinkById } from "../../repositories/appLink.repository";
 import { logAppLinkUpdate } from "../../jobs/appLink.jobs";
 import { formatAppLink } from "../../resources/admin/appLink.resource";
 
-export const updateAppLinkHandler = async (req: Request, res: Response) => {
+export const updateAppLinkHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = UpdateAppLinkParamSchema.parse(req.params);
     const { value } = UpdateAppLinkBodySchema.parse(req.body);
@@ -36,6 +44,6 @@ export const updateAppLinkHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "updateAppLink");
-    return res.status(500).json(error("Failed to update app link"));
+    return next(err);
   }
 };

--- a/src/routes/admin/appSetting.controller.ts
+++ b/src/routes/admin/appSetting.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { GetAppSettingsRequestSchema } from "../../requests/admin/appSetting.request";
 import { findAllAppSettings } from "../../repositories/appSetting.repository";
 import { formatAppSettingsList } from "../../resources/admin/appSetting.resource";
@@ -18,7 +18,11 @@ import { softDeleteAppSetting } from "../../repositories/appSetting.repository";
 import { logAppSettingDeleted } from "../../jobs/appSetting.jobs";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAppSettings = async (req: Request, res: Response) => {
+export const getAppSettings = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const parsed = GetAppSettingsRequestSchema.parse(req.query);
 
@@ -37,12 +41,16 @@ export const getAppSettings = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "getAppSettings");
-    return res.status(500).json(error("Failed to fetch app settings"));
+    return next(err);
   }
 };
 
 
-export const createAppSettingHandler = async (req: Request, res: Response) => {
+export const createAppSettingHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const body = CreateAppSettingRequestSchema.parse(req.body);
 
@@ -55,12 +63,16 @@ export const createAppSettingHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "createAppSetting");
-    return res.status(500).json(error("Failed to create app setting"));
+    return next(err);
   }
 };
 
 
-export const updateAppSettingHandler = async (req: Request, res: Response) => {
+export const updateAppSettingHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = UpdateAppSettingParamSchema.parse(req.params);
     const body = UpdateAppSettingRequestSchema.parse(req.body);
@@ -74,12 +86,16 @@ export const updateAppSettingHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "updateAppSetting");
-    return res.status(500).json(error("Failed to update app setting"));
+    return next(err);
   }
 };
 
 
-export const deleteAppSettingHandler = async (req: Request, res: Response) => {
+export const deleteAppSettingHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = DeleteAppSettingParamSchema.parse(req.params);
 
@@ -90,6 +106,6 @@ export const deleteAppSettingHandler = async (req: Request, res: Response) => {
     return res.json(success("App setting deleted successfully"));
   } catch (err) {
     captureError(err, "deleteAppSetting");
-    return res.status(500).json(error("Failed to delete app setting"));
+    return next(err);
   }
 };

--- a/src/routes/admin/appVariable.controller.ts
+++ b/src/routes/admin/appVariable.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { getAppVariables } from "../../repositories/appVariable.repository";
 import { formatAppVariableList } from "../../resources/admin/appVariable.resource";
 import { captureError } from "../../telemetry/sentry";
@@ -16,17 +16,25 @@ import { success, error } from "../../utils/responseWrapper";
 
 
 
-export const getAppVariablesHandler = async (req: Request, res: Response) => {
+export const getAppVariablesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const vars = await getAppVariables();
     return res.json(success("Variables fetched", formatAppVariableList(vars)));
   } catch (err) {
     captureError(err, "getAppVariables");
-    return res.status(500).json(error("Failed to load app variables"));
+    return next(err);
   }
 };
 
-export const createAppVariableHandler = async (req: Request, res: Response) => {
+export const createAppVariableHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const body = CreateAppVariableSchema.parse(req.body);
 
@@ -38,11 +46,15 @@ export const createAppVariableHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "createAppVariable");
-    return res.status(500).json(error("Failed to create app variable"));
+    return next(err);
   }
 };
 
-export const updateAppVariableHandler = async (req: Request, res: Response) => {
+export const updateAppVariableHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = UpdateAppVariableParamSchema.parse(req.params);
     const body = UpdateAppVariableBodySchema.parse(req.body);
@@ -55,6 +67,6 @@ export const updateAppVariableHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "updateAppVariable");
-    return res.status(500).json(error("Failed to update app variable"));
+    return next(err);
   }
 };

--- a/src/routes/admin/auth.controller.ts
+++ b/src/routes/admin/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { AdminLoginRequestSchema } from "../../requests/admin/auth.request";
 import { findAdminByEmail } from "../../repositories/admin.repository";
 import { hashPassword, comparePassword } from "../../utils/hash";
@@ -14,7 +14,11 @@ import { issueAuthToken } from "../../utils/authToken";
 import { signJwt } from "../../utils/jwt";
 import { success, error } from "../../utils/responseWrapper";
 
-export const loginAdmin = async (req: Request, res: Response) => {
+export const loginAdmin = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { email, password } = AdminLoginRequestSchema.parse(req.body);
 
@@ -49,6 +53,6 @@ export const loginAdmin = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "adminLogin");
-    return res.status(500).json(error("Login failed"));
+    return next(err);
   }
 };

--- a/src/routes/admin/export.controller.ts
+++ b/src/routes/admin/export.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { ExportUserParamSchema } from "../../requests/admin/export.request";
 import { getAllUsersForExport } from "../../repositories/user.repository";
 import { logUserExport } from "../../jobs/export.jobs";
@@ -7,7 +7,11 @@ import XLSX from "xlsx";
 import { captureError } from "../../telemetry/sentry";
 import { error } from "../../utils/responseWrapper";
 
-export const exportUsersHandler = async (req: Request, res: Response) => {
+export const exportUsersHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { type } = ExportUserParamSchema.parse(req.params);
     const users = await getAllUsersForExport();
@@ -38,6 +42,6 @@ export const exportUsersHandler = async (req: Request, res: Response) => {
     return res.status(400).json(error("Unsupported export type"));
   } catch (err) {
     captureError(err, "exportUsers");
-    return res.status(500).json(error("Failed to export users"));
+    return next(err);
   }
 };

--- a/src/routes/admin/profile.controller.ts
+++ b/src/routes/admin/profile.controller.ts
@@ -1,11 +1,15 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { findAdminById } from "../../repositories/admin.repository";
 import { formatAdminResponse } from "../../resources/admin/admin.resource";
 import { AdminMessages } from "../../constants/messages";
 import { captureError } from "../../telemetry/sentry";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAdminProfile = async (req: Request, res: Response) => {
+export const getAdminProfile = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const adminId = req.user?.id!;
     const admin = await findAdminById(adminId);
@@ -17,6 +21,6 @@ export const getAdminProfile = async (req: Request, res: Response) => {
     return res.json(success("Admin fetched", formatAdminResponse(admin)));
   } catch (err) {
     captureError(err, "getAdminProfile");
-    return res.status(500).json(error("Failed to load admin profile"));
+    return next(err);
   }
 };

--- a/src/routes/admin/user.controller.ts
+++ b/src/routes/admin/user.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import {
   getAllUsers,
@@ -26,17 +26,25 @@ import { success, error } from "../../utils/responseWrapper";
 
 const prisma = new PrismaClient();
 
-export const getAllUsersHandler = async (req: Request, res: Response) => {
+export const getAllUsersHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const users = await getAllUsers();
     return res.json(success("Users fetched", formatUserListForAdmin(users)));
   } catch (err) {
     captureError(err, "getAllUsers");
-    return res.status(500).json(error("Failed to load users"));
+    return next(err);
   }
 };
 
-export const updateUserHandler = async (req: Request, res: Response) => {
+export const updateUserHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = UpdateUserParamSchema.parse(req.params);
     const body = UpdateUserBodySchema.parse(req.body);
@@ -50,11 +58,15 @@ export const updateUserHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "updateUser");
-    return res.status(500).json(error("Failed to update user"));
+    return next(err);
   }
 };
 
-export const toggleUserStatusHandler = async (req: Request, res: Response) => {
+export const toggleUserStatusHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = ToggleUserParamSchema.parse(req.params);
     const user = await toggleUserStatus(Number(id));
@@ -66,11 +78,15 @@ export const toggleUserStatusHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "toggleUserStatus");
-    return res.status(500).json(error("Failed to toggle user"));
+    return next(err);
   }
 };
 
-export const deleteUserHandler = async (req: Request, res: Response) => {
+export const deleteUserHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = DeleteUserParamSchema.parse(req.params);
     const user = await softDeleteUser(Number(id));
@@ -82,6 +98,6 @@ export const deleteUserHandler = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "deleteUser");
-    return res.status(500).json(error("Failed to delete user"));
+    return next(err);
   }
 };

--- a/src/routes/user/auth.controller.ts
+++ b/src/routes/user/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import {
   findUserByEmail,
@@ -28,7 +28,11 @@ import { success, error } from "../../utils/responseWrapper";
 
 const prisma = new PrismaClient();
 
-const registerUser = async (req: Request, res: Response) => {
+const registerUser = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { name, email, password } = req.body;
 
@@ -64,11 +68,15 @@ const registerUser = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "registerUser");
-    return res.status(500).json(error("Registration failed"));
+    return next(err);
   }
 };
 
-const loginUser = async (req: Request, res: Response) => {
+const loginUser = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const emailVO = new Email(req.body.email);
     const passwordVO = new Password(req.body.password);
@@ -107,21 +115,29 @@ const loginUser = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "loginUser");
-    return res.status(500).json(error("Login failed"));
+    return next(err);
   }
 };
 
-const socialLogin = async (req: Request, res: Response) => {
+const socialLogin = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     // Social login is not supported by the current schema
     return res.status(400).json(error("Social login is not supported."));
   } catch (err) {
     captureError(err, "socialLogin");
-    return res.status(500).json(error("Social login failed"));
+    return next(err);
   }
 };
 
-const appleDetails = async (req: Request, res: Response) => {
+const appleDetails = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { id } = req.params;
 
@@ -134,11 +150,15 @@ const appleDetails = async (req: Request, res: Response) => {
       .json(error("Apple details lookup is not supported."));
   } catch (err) {
     captureError(err, "appleDetails");
-    return res.status(500).json(error("Failed to fetch apple details"));
+    return next(err);
   }
 };
 
-const sendOtp = async (req: Request, res: Response) => {
+const sendOtp = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { email } = req.body;
 
@@ -152,11 +172,15 @@ const sendOtp = async (req: Request, res: Response) => {
     return res.json(success("OTP sent to email"));
   } catch (err) {
     captureError(err, "sendOtp");
-    return res.status(500).json(error("Failed to send OTP"));
+    return next(err);
   }
 };
 
-const forgotPassword = async (req: Request, res: Response) => {
+const forgotPassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const emailVO = new Email(req.body.email);
 
@@ -174,7 +198,7 @@ const forgotPassword = async (req: Request, res: Response) => {
     return res.json(success("Password reset link sent", { resetUrl }));
   } catch (err) {
     captureError(err, "forgotPassword");
-    return res.status(500).json(error("Failed to send reset link"));
+    return next(err);
   }
 };
 

--- a/src/routes/user/init.controller.ts
+++ b/src/routes/user/init.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import { formatInitAppResponse } from "../../resources/user/init.resource";
 import { success, error } from "../../utils/responseWrapper";
@@ -6,7 +6,11 @@ import { logger } from "../../utils/logger";
 
 const prisma = new PrismaClient();
 
-export const initApp = async (req: Request, res: Response) => {
+export const initApp = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { app_type } = req.params;
 
   try {
@@ -21,6 +25,6 @@ export const initApp = async (req: Request, res: Response) => {
     return res.json(success("App settings fetched", formatInitAppResponse(setting)));
   } catch (err) {
     logger.error("InitApp Error:", err);
-    return res.status(500).json(error("Server error"));
+    return next(err);
   }
 };

--- a/src/routes/user/notification.controller.ts
+++ b/src/routes/user/notification.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { findUserNotifications } from "../../repositories/notification.repository";
 import { formatNotificationList } from "../../resources/user/notification.resource";
 import { captureError } from "../../telemetry/sentry";
@@ -10,18 +10,26 @@ import { logNotificationClear } from "../../jobs/notification.jobs";
 import { Messages } from "../../constants/messages";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getNotifications = async (req: Request, res: Response) => {
+export const getNotifications = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user!.id;
     const notifications = await findUserNotifications(userId);
     return res.json(success("Notifications fetched", formatNotificationList(notifications)));
   } catch (err) {
     captureError(err, "getNotifications");
-    return res.status(500).json(error("Failed to load notifications"));
+    return next(err);
   }
 };
 
-export const changeNotificationStatus = async (req: Request, res: Response) => {
+export const changeNotificationStatus = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { status } = NotificationStatusParamSchema.parse(req.params);
     const userId = req.user!.id;
@@ -35,13 +43,15 @@ export const changeNotificationStatus = async (req: Request, res: Response) => {
     return res.json(success(`Marked ${updatedCount} as ${status}`));
   } catch (err) {
     captureError(err, "changeNotificationStatus");
-    return res
-      .status(500)
-      .json(error("Failed to update notification status"));
+    return next(err);
   }
 };
 
-export const clearAllNotifications = async (req: Request, res: Response) => {
+export const clearAllNotifications = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user!.id;
 
@@ -54,6 +64,6 @@ export const clearAllNotifications = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "clearAllNotifications");
-    return res.status(500).json(error("Failed to clear notifications"));
+    return next(err);
   }
 };

--- a/src/routes/user/password.controller.ts
+++ b/src/routes/user/password.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import {
   ChangePasswordRequestSchema,
   ResetPasswordBodySchema,
@@ -21,7 +21,11 @@ import { userEmitter } from "../../events/emitters/userEmitter";
 import { success, error } from "../../utils/responseWrapper";
 import { getUserIdFromToken, deleteResetToken } from "../../utils/resetToken";
 
-export const changePassword = async (req: Request, res: Response) => {
+export const changePassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user!.id;
     const { current_password, new_password } =
@@ -56,11 +60,15 @@ export const changePassword = async (req: Request, res: Response) => {
     return res.json(success("Password changed successfully"));
   } catch (err) {
     captureError(err, "changePassword");
-    return res.status(500).json(error("Failed to change password"));
+    return next(err);
   }
 };
 
-export const resetPassword = async (req: Request, res: Response) => {
+export const resetPassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { token } = ResetPasswordParamsSchema.parse(req.params);
     const { new_password } = ResetPasswordBodySchema.parse(req.body);
@@ -79,6 +87,6 @@ export const resetPassword = async (req: Request, res: Response) => {
     return res.json(success("Password reset successfully"));
   } catch (err) {
     captureError(err, "resetPassword");
-    return res.status(500).json(error("Failed to reset password"));
+    return next(err);
   }
 };

--- a/src/routes/user/profile.controller.ts
+++ b/src/routes/user/profile.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import {
   findUserById,
   updateUserById,
@@ -13,7 +13,11 @@ import { UpdateProfileRequestSchema } from "../../resources/user/profile.request
 import { logUserUpdate } from "../../jobs/profile.jobs";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getProfile = async (req: Request, res: Response) => {
+export const getProfile = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user?.id;
     const user = await findUserById(userId!);
@@ -26,12 +30,15 @@ export const getProfile = async (req: Request, res: Response) => {
     return res.json(success("User fetched successfully", formatUserResponse(user)));
   } catch (err) {
     captureError(err, "getProfile");
-    // return res.status(500).json({ message: "Server error" });
-    return res.status(500).json(error("Failed to load profile"));
+    return next(err);
   }
 };
 
-export const updateProfile = async (req: Request, res: Response) => {
+export const updateProfile = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user?.id!;
     const body = UpdateProfileRequestSchema.parse(req.body);
@@ -58,6 +65,6 @@ export const updateProfile = async (req: Request, res: Response) => {
     );
   } catch (err) {
     captureError(err, "updateProfile");
-    return res.status(500).json(error("Update failed"));
+    return next(err);
   }
 };

--- a/src/routes/user/session.controller.ts
+++ b/src/routes/user/session.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { destroySession } from "../../utils/session";
 import { clearAllUserSessionKeys } from "../../utils/passwordAttempt";
 import { invalidateAuthToken } from "../../utils/authToken";
@@ -7,7 +7,11 @@ import { captureError } from "../../telemetry/sentry";
 import { Messages } from "../../constants/messages";
 import { success, error } from "../../utils/responseWrapper";
 
-export const logout = async (req: Request, res: Response) => {
+export const logout = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const userId = req.user?.id;
 
@@ -19,6 +23,6 @@ export const logout = async (req: Request, res: Response) => {
     return res.json(success(Messages.logoutSuccess));
   } catch (err) {
     captureError(err, "logout");
-    return res.status(500).json(error("Logout failed"));
+    return next(err);
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ export const startServer = async (): Promise<Server> => {
   app.use((req, res, next) => {
     if (typeof res.setHeader !== "function") {
       logger.error("res.setHeader is not a function!", res);
-      return res.status(500).json(error("res.setHeader is not a function"));
+      return next(new Error("res.setHeader is not a function"));
     }
     next();
   });


### PR DESCRIPTION
## Summary
- route controllers now forward errors to a global handler
- global error handler truncates stack to the first five lines
- middleware returns errors with `next()` instead of sending 500s
- remove direct 500 responses in server setup

## Testing
- `npx tsc -p tsconfig.json --skipLibCheck true --noEmit` *(fails: file tests/... is not under rootDir)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767326c9bc8324bce11631b2d4dccb