### PR TITLE
Introduce async error handler

### DIFF
--- a/src/routes/admin/appLink.controller.ts
+++ b/src/routes/admin/appLink.controller.ts
@@ -1,22 +1,15 @@
 import { Request, Response, NextFunction } from "express";
 import { getAppLinks } from "../../repositories/appLink.repository";
 import { formatAppLinksList } from "../../resources/admin/appLink.resource";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAppLinksHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getAppLinksHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const links = await getAppLinks();
     return res.json(success("Links fetched", formatAppLinksList(links)));
-  } catch (err) {
-    captureError(err, "getAppLinks");
-    return next(err);
   }
-};
+);
 
 import {
   UpdateAppLinkBodySchema,
@@ -26,12 +19,8 @@ import { updateAppLinkById } from "../../repositories/appLink.repository";
 import { logAppLinkUpdate } from "../../jobs/appLink.jobs";
 import { formatAppLink } from "../../resources/admin/appLink.resource";
 
-export const updateAppLinkHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const updateAppLinkHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = UpdateAppLinkParamSchema.parse(req.params);
     const { value } = UpdateAppLinkBodySchema.parse(req.body);
 
@@ -42,8 +31,5 @@ export const updateAppLinkHandler = async (
     return res.json(
       success("Link updated", formatAppLink(updated))
     );
-  } catch (err) {
-    captureError(err, "updateAppLink");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/appSetting.controller.ts
+++ b/src/routes/admin/appSetting.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { GetAppSettingsRequestSchema } from "../../requests/admin/appSetting.request";
 import { findAllAppSettings } from "../../repositories/appSetting.repository";
 import { formatAppSettingsList } from "../../resources/admin/appSetting.resource";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { CreateAppSettingRequestSchema } from "../../requests/admin/appSetting.request";
 import { createAppSetting } from "../../repositories/appSetting.repository";
 import { formatAppSetting } from "../../resources/admin/appSetting.resource";
@@ -18,12 +18,8 @@ import { softDeleteAppSetting } from "../../repositories/appSetting.repository";
 import { logAppSettingDeleted } from "../../jobs/appSetting.jobs";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAppSettings = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getAppSettings = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const parsed = GetAppSettingsRequestSchema.parse(req.query);
 
     const { data, pagination } = await findAllAppSettings({
@@ -39,19 +35,12 @@ export const getAppSettings = async (
         pagination,
       })
     );
-  } catch (err) {
-    captureError(err, "getAppSettings");
-    return next(err);
   }
-};
+);
 
 
-export const createAppSettingHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const createAppSettingHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const body = CreateAppSettingRequestSchema.parse(req.body);
 
     const setting = await createAppSetting(body);
@@ -61,19 +50,12 @@ export const createAppSettingHandler = async (
     return res.status(201).json(
       success("App setting created", formatAppSetting(setting))
     );
-  } catch (err) {
-    captureError(err, "createAppSetting");
-    return next(err);
   }
-};
+);
 
 
-export const updateAppSettingHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const updateAppSettingHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = UpdateAppSettingParamSchema.parse(req.params);
     const body = UpdateAppSettingRequestSchema.parse(req.body);
 
@@ -84,19 +66,12 @@ export const updateAppSettingHandler = async (
     return res.json(
       success("App setting updated", formatAppSetting(setting))
     );
-  } catch (err) {
-    captureError(err, "updateAppSetting");
-    return next(err);
   }
-};
+);
 
 
-export const deleteAppSettingHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const deleteAppSettingHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = DeleteAppSettingParamSchema.parse(req.params);
 
     await softDeleteAppSetting(Number(id));
@@ -104,8 +79,5 @@ export const deleteAppSettingHandler = async (
     logAppSettingDeleted(Number(id));
 
     return res.json(success("App setting deleted successfully"));
-  } catch (err) {
-    captureError(err, "deleteAppSetting");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/appVariable.controller.ts
+++ b/src/routes/admin/appVariable.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { getAppVariables } from "../../repositories/appVariable.repository";
 import { formatAppVariableList } from "../../resources/admin/appVariable.resource";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { CreateAppVariableSchema } from "../../requests/admin/appVariable.request";
 import { createAppVariable } from "../../repositories/appVariable.repository";
 import { logAppVariableCreated } from "../../jobs/appVariable.jobs";
@@ -16,26 +16,15 @@ import { success, error } from "../../utils/responseWrapper";
 
 
 
-export const getAppVariablesHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getAppVariablesHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const vars = await getAppVariables();
     return res.json(success("Variables fetched", formatAppVariableList(vars)));
-  } catch (err) {
-    captureError(err, "getAppVariables");
-    return next(err);
   }
-};
+);
 
-export const createAppVariableHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const createAppVariableHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const body = CreateAppVariableSchema.parse(req.body);
 
     const variable = await createAppVariable(body);
@@ -44,18 +33,11 @@ export const createAppVariableHandler = async (
     return res.status(201).json(
       success("App variable created", formatAppVariable(variable))
     );
-  } catch (err) {
-    captureError(err, "createAppVariable");
-    return next(err);
   }
-};
+);
 
-export const updateAppVariableHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const updateAppVariableHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = UpdateAppVariableParamSchema.parse(req.params);
     const body = UpdateAppVariableBodySchema.parse(req.body);
 
@@ -65,8 +47,5 @@ export const updateAppVariableHandler = async (
     return res.json(
       success("App variable updated", formatAppVariable(updated))
     );
-  } catch (err) {
-    captureError(err, "updateAppVariable");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/auth.controller.ts
+++ b/src/routes/admin/auth.controller.ts
@@ -8,18 +8,14 @@ import { AdminEntity } from "../../domain/entities/admin.entity";
 import { formatAdminResponse } from "../../resources/admin/admin.resource";
 import { logAdminLogin } from "../../jobs/admin.jobs";
 import { AdminPassword } from "../../domain/valueObjects/adminPassword.vo";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { appEmitter, APP_EVENTS } from "../../events/emitters/appEmitter";
 import { issueAuthToken } from "../../utils/authToken";
 import { signJwt } from "../../utils/jwt";
 import { success, error } from "../../utils/responseWrapper";
 
-export const loginAdmin = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const loginAdmin = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { email, password } = AdminLoginRequestSchema.parse(req.body);
 
     const admin = await findAdminByEmail(email);
@@ -51,8 +47,5 @@ export const loginAdmin = async (
         token,
       })
     );
-  } catch (err) {
-    captureError(err, "adminLogin");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/export.controller.ts
+++ b/src/routes/admin/export.controller.ts
@@ -4,15 +4,11 @@ import { getAllUsersForExport } from "../../repositories/user.repository";
 import { logUserExport } from "../../jobs/export.jobs";
 import { Parser } from "json2csv";
 import XLSX from "xlsx";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { error } from "../../utils/responseWrapper";
 
-export const exportUsersHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const exportUsersHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { type } = ExportUserParamSchema.parse(req.params);
     const users = await getAllUsersForExport();
 
@@ -40,8 +36,5 @@ export const exportUsersHandler = async (
     }
 
     return res.status(400).json(error("Unsupported export type"));
-  } catch (err) {
-    captureError(err, "exportUsers");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/profile.controller.ts
+++ b/src/routes/admin/profile.controller.ts
@@ -2,15 +2,11 @@ import { Request, Response, NextFunction } from "express";
 import { findAdminById } from "../../repositories/admin.repository";
 import { formatAdminResponse } from "../../resources/admin/admin.resource";
 import { AdminMessages } from "../../constants/messages";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getAdminProfile = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getAdminProfile = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const adminId = req.user?.id!;
     const admin = await findAdminById(adminId);
 
@@ -19,8 +15,5 @@ export const getAdminProfile = async (
     }
 
     return res.json(success("Admin fetched", formatAdminResponse(admin)));
-  } catch (err) {
-    captureError(err, "getAdminProfile");
-    return next(err);
   }
-};
+);

--- a/src/routes/admin/user.controller.ts
+++ b/src/routes/admin/user.controller.ts
@@ -10,7 +10,7 @@ import {
   formatUserListForAdmin,
   formatUserForAdmin,
 } from "../../resources/admin/user.resource";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import {
   UpdateUserParamSchema,
   UpdateUserBodySchema,
@@ -26,26 +26,15 @@ import { success, error } from "../../utils/responseWrapper";
 
 const prisma = new PrismaClient();
 
-export const getAllUsersHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getAllUsersHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const users = await getAllUsers();
     return res.json(success("Users fetched", formatUserListForAdmin(users)));
-  } catch (err) {
-    captureError(err, "getAllUsers");
-    return next(err);
   }
-};
+);
 
-export const updateUserHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const updateUserHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = UpdateUserParamSchema.parse(req.params);
     const body = UpdateUserBodySchema.parse(req.body);
 
@@ -56,18 +45,11 @@ export const updateUserHandler = async (
     return res.json(
       success("User updated successfully", formatUserForAdmin(updated))
     );
-  } catch (err) {
-    captureError(err, "updateUser");
-    return next(err);
   }
-};
+);
 
-export const toggleUserStatusHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const toggleUserStatusHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = ToggleUserParamSchema.parse(req.params);
     const user = await toggleUserStatus(Number(id));
 
@@ -76,18 +58,11 @@ export const toggleUserStatusHandler = async (
     return res.json(
       success(`User ${user.status ? "activated" : "deactivated"}`, formatUserForAdmin(user))
     );
-  } catch (err) {
-    captureError(err, "toggleUserStatus");
-    return next(err);
   }
-};
+);
 
-export const deleteUserHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const deleteUserHandler = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = DeleteUserParamSchema.parse(req.params);
     const user = await softDeleteUser(Number(id));
 
@@ -96,8 +71,5 @@ export const deleteUserHandler = async (
     return res.json(
       success("User deleted successfully", formatUserForAdmin(user))
     );
-  } catch (err) {
-    captureError(err, "deleteUser");
-    return next(err);
   }
-};
+);

--- a/src/routes/user/init.controller.ts
+++ b/src/routes/user/init.controller.ts
@@ -3,17 +3,14 @@ import { PrismaClient } from "@prisma/client";
 import { formatInitAppResponse } from "../../resources/user/init.resource";
 import { success, error } from "../../utils/responseWrapper";
 import { logger } from "../../utils/logger";
+import { asyncHandler } from "../../utils/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const initApp = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  const { app_type } = req.params;
+export const initApp = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { app_type } = req.params;
 
-  try {
     const setting = await prisma.appSetting.findFirst({
       where: { app_type },
     });
@@ -22,9 +19,8 @@ export const initApp = async (
       return res.status(404).json(error("App settings not found"));
     }
 
-    return res.json(success("App settings fetched", formatInitAppResponse(setting)));
-  } catch (err) {
-    logger.error("InitApp Error:", err);
-    return next(err);
+    return res.json(
+      success("App settings fetched", formatInitAppResponse(setting))
+    );
   }
-};
+);

--- a/src/routes/user/password.controller.ts
+++ b/src/routes/user/password.controller.ts
@@ -16,17 +16,13 @@ import {
   clearFailedAttempts,
 } from "../../utils/passwordAttempt";
 import { logPasswordChange } from "../../jobs/password.jobs";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { userEmitter } from "../../events/emitters/userEmitter";
 import { success, error } from "../../utils/responseWrapper";
 import { getUserIdFromToken, deleteResetToken } from "../../utils/resetToken";
 
-export const changePassword = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const changePassword = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.user!.id;
     const { current_password, new_password } =
       ChangePasswordRequestSchema.parse(req.body);
@@ -58,18 +54,11 @@ export const changePassword = async (
     userEmitter.emit("user.passwordChanged", { userId });
 
     return res.json(success("Password changed successfully"));
-  } catch (err) {
-    captureError(err, "changePassword");
-    return next(err);
   }
-};
+);
 
-export const resetPassword = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const resetPassword = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const { token } = ResetPasswordParamsSchema.parse(req.params);
     const { new_password } = ResetPasswordBodySchema.parse(req.body);
 
@@ -85,8 +74,5 @@ export const resetPassword = async (
     userEmitter.emit("user.passwordReset", { userId: Number(userId) });
 
     return res.json(success("Password reset successfully"));
-  } catch (err) {
-    captureError(err, "resetPassword");
-    return next(err);
   }
-};
+);

--- a/src/routes/user/profile.controller.ts
+++ b/src/routes/user/profile.controller.ts
@@ -5,7 +5,7 @@ import {
 } from "../../repositories/user.repository";
 import { formatUserResponse } from "../../resources/user/user.resource";
 import { Messages } from "../../constants/messages";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { Email } from "../../domain/valueObjects/email.vo";
 import { Name } from "../../domain/valueObjects/name.vo";
 import { UserEntity } from "../../domain/entities/user.entity";
@@ -13,12 +13,8 @@ import { UpdateProfileRequestSchema } from "../../resources/user/profile.request
 import { logUserUpdate } from "../../jobs/profile.jobs";
 import { success, error } from "../../utils/responseWrapper";
 
-export const getProfile = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const getProfile = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.user?.id;
     const user = await findUserById(userId!);
 
@@ -28,18 +24,11 @@ export const getProfile = async (
 
     // return res.json({ user: formatUserResponse(user) });
     return res.json(success("User fetched successfully", formatUserResponse(user)));
-  } catch (err) {
-    captureError(err, "getProfile");
-    return next(err);
   }
-};
+);
 
-export const updateProfile = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const updateProfile = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.user?.id!;
     const body = UpdateProfileRequestSchema.parse(req.body);
 
@@ -63,8 +52,5 @@ export const updateProfile = async (
     return res.json(
       success("Profile updated successfully", formatUserResponse(userEntity))
     );
-  } catch (err) {
-    captureError(err, "updateProfile");
-    return next(err);
   }
-};
+);

--- a/src/routes/user/session.controller.ts
+++ b/src/routes/user/session.controller.ts
@@ -3,16 +3,12 @@ import { destroySession } from "../../utils/session";
 import { clearAllUserSessionKeys } from "../../utils/passwordAttempt";
 import { invalidateAuthToken } from "../../utils/authToken";
 import { logLogout } from "../../jobs/session.jobs";
-import { captureError } from "../../telemetry/sentry";
+import { asyncHandler } from "../../utils/asyncHandler";
 import { Messages } from "../../constants/messages";
 import { success, error } from "../../utils/responseWrapper";
 
-export const logout = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
+export const logout = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.user?.id;
 
     await clearAllUserSessionKeys(userId!);
@@ -21,8 +17,5 @@ export const logout = async (
     logLogout(userId!);
 
     return res.json(success(Messages.logoutSuccess));
-  } catch (err) {
-    captureError(err, "logout");
-    return next(err);
   }
-};
+);

--- a/src/utils/asyncHandler.ts
+++ b/src/utils/asyncHandler.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const asyncHandler = <T extends (req: Request, res: Response, next: NextFunction) => any>(
+  fn: T
+) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};


### PR DESCRIPTION
## Summary
- add a small `asyncHandler` helper
- simplify controllers by removing local `try/catch` blocks

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687675b128b8832491256b756059dbc2