### PR TITLE
Fix variable shadowing in password controller

### DIFF
--- a/src/routes/user/password.controller.ts
+++ b/src/routes/user/password.controller.ts
@@ -37,7 +37,7 @@ export const changePassword = asyncHandler(
     if (!user) return res.status(404).json(error("User not found"));
 
     const current = new Password(current_password);
-    const next = new Password(new_password);
+    const nextPassword = new Password(new_password);
 
     const match = await comparePassword(current.getValue(), user.password);
     if (!match) {
@@ -45,7 +45,7 @@ export const changePassword = asyncHandler(
       return res.status(401).json(error("Current password is incorrect"));
     }
 
-    const hashed = await hashPassword(next.getValue());
+    const hashed = await hashPassword(nextPassword.getValue());
 
     await changeUserPassword(userId, hashed);
     await clearFailedAttempts(userId);
@@ -65,8 +65,8 @@ export const resetPassword = asyncHandler(
     const userId = await getUserIdFromToken(token);
     if (!userId) return res.status(400).json(error("Invalid or expired token"));
 
-    const next = new Password(new_password);
-    const hashed = await hashPassword(next.getValue());
+    const nextPassword = new Password(new_password);
+    const hashed = await hashPassword(nextPassword.getValue());
 
     await changeUserPassword(Number(userId), hashed);
     await deleteResetToken(token);


### PR DESCRIPTION
## Summary
- resolve `next` variable name conflicts in password controller

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6876779dd42c8324baf67ff01f18f95c