### PR TITLE
Refactor repositories to be read-only

### DIFF
--- a/src/repositories/appLink.repository.ts
+++ b/src/repositories/appLink.repository.ts
@@ -6,13 +6,3 @@ export const getAppLinks = async () => {
     orderBy: { created_at: "desc" },
   });
 };
-
-export const updateAppLinkById = async (
-  id: number,
-  data: { value: string }
-) => {
-  return prisma.appMenuLink.update({
-    where: { id },
-    data,
-  });
-};

--- a/src/repositories/appSetting.repository.ts
+++ b/src/repositories/appSetting.repository.ts
@@ -34,37 +34,8 @@ export const findAllAppSettings = async ({
   };
 };
 
-export const createAppSetting = async (data: {
-  app_label: string;
-  app_type: string;
-  app_version: number;
-  force_updates: boolean;
-  maintenance_mode: boolean;
-}) => {
-  return prisma.appSetting.create({ data });
-};
-
-export const updateAppSetting = async (
-  id: number,
-  data: {
-    app_label: string;
-    app_type: string;
-    app_version: number;
-    force_updates: boolean;
-    maintenance_mode: boolean;
-  }
-) => {
-  return prisma.appSetting.update({
-    where: { id },
-    data,
+export const findAppSettingByType = async (app_type: string) => {
+  return prisma.appSetting.findFirst({
+    where: { app_type },
   });
-};
-
-export const softDeleteAppSetting = async (id: number): Promise<boolean> => {
-  await prisma.appSetting.update({
-    where: { id },
-    data: { deleted_at: new Date() },
-  });
-
-  return true;
 };

--- a/src/repositories/appVariable.repository.ts
+++ b/src/repositories/appVariable.repository.ts
@@ -6,17 +6,3 @@ export const getAppVariables = async () => {
     orderBy: { created_at: "desc" },
   });
 };
-
-export const createAppVariable = async (data: { name: string; value: string }) => {
-  return prisma.appVariable.create({ data });
-};
-
-export const updateAppVariable = async (
-  id: number,
-  data: { name: string; value: string }
-) => {
-  return prisma.appVariable.update({
-    where: { id },
-    data,
-  });
-};

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -14,23 +14,3 @@ export const findUserNotifications = async (userId: number): Promise<Notificatio
       new NotificationEntity(n.id, n.user_id, n.title, n.message, n.read, n.created_at)
   );
 };
-
-export const updateUserNotificationStatus = async (
-  userId: number,
-  read: boolean
-): Promise<number> => {
-  const result = await prisma.notification.updateMany({
-    where: { user_id: userId },
-    data: { read },
-  });
-
-  return result.count;
-};
-
-export const deleteAllNotificationsForUser = async (userId: number): Promise<number> => {
-  const result = await prisma.notification.deleteMany({
-    where: { user_id: userId },
-  });
-
-  return result.count;
-};

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,6 +1,5 @@
 import { PrismaClient } from "@prisma/client";
 import { UserEntity } from "../domain/entities/user.entity";
-import bcrypt from "bcrypt";
 
 const prisma = new PrismaClient();
 
@@ -14,33 +13,6 @@ export const findUserById = async (id: number): Promise<UserEntity | null> => {
   return new UserEntity(user.id, user.name, user.email);
 };
 
-export const createUser = async (data: {
-  name: string;
-  email: string;
-  password: string;
-}) => {
-  return prisma.user.create({ data });
-};
-
-export const updateUserById = async (
-  id: number,
-  data: { name?: string; email?: string; status?: boolean }
-) => {
-  return prisma.user.update({
-    where: { id },
-    data,
-  });
-};
-
-export const changeUserPassword = async (
-  userId: number,
-  newPassword: string
-) => {
-  return prisma.user.update({
-    where: { id: userId },
-    data: { password: newPassword },
-  });
-};
 
 export const getAllUsers = async () => {
   return prisma.user.findMany({
@@ -48,22 +20,6 @@ export const getAllUsers = async () => {
   });
 };
 
-export const toggleUserStatus = async (id: number): Promise<any> => {
-  const user = await prisma.user.findUnique({ where: { id } });
-  if (!user) throw new Error("User not found");
-
-  return prisma.user.update({
-    where: { id },
-    data: { status: !user.status },
-  });
-};
-
-export const softDeleteUser = async (id: number): Promise<any> => {
-  return prisma.user.update({
-    where: { id },
-    data: { deleted_at: new Date() },
-  });
-};
 
 export const getAllUsersForExport = async () => {
   return prisma.user.findMany({

--- a/src/routes/admin/appLink.controller.ts
+++ b/src/routes/admin/appLink.controller.ts
@@ -15,7 +15,7 @@ import {
   UpdateAppLinkBodySchema,
   UpdateAppLinkParamSchema,
 } from "../../requests/admin/appLink.request";
-import { updateAppLinkById } from "../../repositories/appLink.repository";
+import { updateAppLinkById } from "../../services/appLink.service";
 import { logAppLinkUpdate } from "../../jobs/appLink.jobs";
 import { formatAppLink } from "../../resources/admin/appLink.resource";
 

--- a/src/routes/admin/appSetting.controller.ts
+++ b/src/routes/admin/appSetting.controller.ts
@@ -4,17 +4,17 @@ import { findAllAppSettings } from "../../repositories/appSetting.repository";
 import { formatAppSettingsList } from "../../resources/admin/appSetting.resource";
 import { asyncHandler } from "../../utils/asyncHandler";
 import { CreateAppSettingRequestSchema } from "../../requests/admin/appSetting.request";
-import { createAppSetting } from "../../repositories/appSetting.repository";
+import { createAppSetting } from "../../services/appSetting.actions";
 import { formatAppSetting } from "../../resources/admin/appSetting.resource";
 import { logAppSettingCreated } from "../../jobs/appSetting.jobs";
 import {
   UpdateAppSettingRequestSchema,
   UpdateAppSettingParamSchema,
 } from "../../requests/admin/appSetting.request";
-import { updateAppSetting } from "../../repositories/appSetting.repository";
+import { updateAppSetting } from "../../services/appSetting.actions";
 import { logAppSettingUpdated } from "../../jobs/appSetting.jobs";
 import { DeleteAppSettingParamSchema } from "../../requests/admin/appSetting.request";
-import { softDeleteAppSetting } from "../../repositories/appSetting.repository";
+import { softDeleteAppSetting } from "../../services/appSetting.actions";
 import { logAppSettingDeleted } from "../../jobs/appSetting.jobs";
 import { success, error } from "../../utils/responseWrapper";
 

--- a/src/routes/admin/appVariable.controller.ts
+++ b/src/routes/admin/appVariable.controller.ts
@@ -3,14 +3,14 @@ import { getAppVariables } from "../../repositories/appVariable.repository";
 import { formatAppVariableList } from "../../resources/admin/appVariable.resource";
 import { asyncHandler } from "../../utils/asyncHandler";
 import { CreateAppVariableSchema } from "../../requests/admin/appVariable.request";
-import { createAppVariable } from "../../repositories/appVariable.repository";
+import { createAppVariable } from "../../services/appVariable.service";
 import { logAppVariableCreated } from "../../jobs/appVariable.jobs";
 import { formatAppVariable } from "../../resources/admin/appVariable.resource";
 import {
   UpdateAppVariableParamSchema,
   UpdateAppVariableBodySchema,
 } from "../../requests/admin/appVariable.request";
-import { updateAppVariable } from "../../repositories/appVariable.repository";
+import { updateAppVariable } from "../../services/appVariable.service";
 import { logAppVariableUpdated } from "../../jobs/appVariable.jobs";
 import { success, error } from "../../utils/responseWrapper";
 

--- a/src/routes/admin/user.controller.ts
+++ b/src/routes/admin/user.controller.ts
@@ -1,11 +1,10 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
+import { getAllUsers } from "../../repositories/user.repository";
 import {
-  getAllUsers,
   updateUserById,
   toggleUserStatus,
   softDeleteUser,
-} from "../../repositories/user.repository";
+} from "../../services/user.service";
 import {
   formatUserListForAdmin,
   formatUserForAdmin,
@@ -24,7 +23,6 @@ import {
 } from "../../jobs/user.jobs";
 import { success, error } from "../../utils/responseWrapper";
 
-const prisma = new PrismaClient();
 
 export const getAllUsersHandler = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/user/auth.controller.ts
+++ b/src/routes/user/auth.controller.ts
@@ -1,9 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
-import {
-  findUserByEmail,
-  createUser,
-} from "../../repositories/user.repository";
+import { findUserByEmail } from "../../repositories/user.repository";
+import { createUser } from "../../services/user.service";
 import { hashPassword, comparePassword } from "../../utils/hash";
 import { generateSession } from "../../utils/session";
 import { formatUserResponse } from "../../resources/user/user.resource";
@@ -27,7 +24,6 @@ import { issueAuthToken } from "../../utils/authToken";
 import { signJwt } from "../../utils/jwt";
 import { success, error } from "../../utils/responseWrapper";
 
-const prisma = new PrismaClient();
 
 const registerUser = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/user/init.controller.ts
+++ b/src/routes/user/init.controller.ts
@@ -1,19 +1,15 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { formatInitAppResponse } from "../../resources/user/init.resource";
 import { success, error } from "../../utils/responseWrapper";
 import { logger } from "../../utils/logger";
 import { asyncHandler } from "../../utils/asyncHandler";
-
-const prisma = new PrismaClient();
+import { getAppSettingByType } from "../../services/appSetting.service";
 
 export const initApp = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {
     const { app_type } = req.params;
 
-    const setting = await prisma.appSetting.findFirst({
-      where: { app_type },
-    });
+    const setting = await getAppSettingByType(app_type);
 
     if (!setting) {
       return res.status(404).json(error("App settings not found"));

--- a/src/routes/user/notification.controller.ts
+++ b/src/routes/user/notification.controller.ts
@@ -3,9 +3,9 @@ import { findUserNotifications } from "../../repositories/notification.repositor
 import { formatNotificationList } from "../../resources/user/notification.resource";
 import { asyncHandler } from "../../utils/asyncHandler";
 import { NotificationStatusParamSchema } from "../../requests/user/notification.request";
-import { updateUserNotificationStatus } from "../../repositories/notification.repository";
+import { updateUserNotificationStatus } from "../../services/notification.service";
 import { logNotificationStatusChange } from "../../jobs/notification.jobs";
-import { deleteAllNotificationsForUser } from "../../repositories/notification.repository";
+import { deleteAllNotificationsForUser } from "../../services/notification.service";
 import { logNotificationClear } from "../../jobs/notification.jobs";
 import { Messages } from "../../constants/messages";
 import { success, error } from "../../utils/responseWrapper";

--- a/src/routes/user/password.controller.ts
+++ b/src/routes/user/password.controller.ts
@@ -5,10 +5,8 @@ import {
   ResetPasswordParamsSchema,
 } from "../../requests/user/password.request";
 import { comparePassword, hashPassword } from "../../utils/hash";
-import {
-  changeUserPassword,
-  findUserWithPasswordById,
-} from "../../repositories/user.repository";
+import { changeUserPassword } from "../../services/user.service";
+import { findUserWithPasswordById } from "../../repositories/user.repository";
 import { Password } from "../../domain/valueObjects/password.vo";
 import {
   isBlocked,

--- a/src/routes/user/profile.controller.ts
+++ b/src/routes/user/profile.controller.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import {
-  findUserById,
-  updateUserById,
-} from "../../repositories/user.repository";
+import { findUserById } from "../../repositories/user.repository";
+import { updateUserById } from "../../services/user.service";
 import { formatUserResponse } from "../../resources/user/user.resource";
 import { Messages } from "../../constants/messages";
 import { asyncHandler } from "../../utils/asyncHandler";

--- a/src/services/appLink.service.ts
+++ b/src/services/appLink.service.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export const updateAppLinkById = async (
+  id: number,
+  data: { value: string }
+) => {
+  return prisma.appMenuLink.update({
+    where: { id },
+    data,
+  });
+};

--- a/src/services/appSetting.actions.ts
+++ b/src/services/appSetting.actions.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export const createAppSetting = async (data: {
+  app_label: string;
+  app_type: string;
+  app_version: number;
+  force_updates: boolean;
+  maintenance_mode: boolean;
+}) => {
+  return prisma.appSetting.create({ data });
+};
+
+export const updateAppSetting = async (
+  id: number,
+  data: {
+    app_label: string;
+    app_type: string;
+    app_version: number;
+    force_updates: boolean;
+    maintenance_mode: boolean;
+  }
+) => {
+  return prisma.appSetting.update({
+    where: { id },
+    data,
+  });
+};
+
+export const softDeleteAppSetting = async (id: number) => {
+  await prisma.appSetting.update({
+    where: { id },
+    data: { deleted_at: new Date() },
+  });
+  return true;
+};

--- a/src/services/appSetting.service.ts
+++ b/src/services/appSetting.service.ts
@@ -1,0 +1,5 @@
+import { findAppSettingByType } from "../repositories/appSetting.repository";
+
+export const getAppSettingByType = async (appType: string) => {
+  return findAppSettingByType(appType);
+};

--- a/src/services/appVariable.service.ts
+++ b/src/services/appVariable.service.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export const createAppVariable = async (data: { name: string; value: string }) => {
+  return prisma.appVariable.create({ data });
+};
+
+export const updateAppVariable = async (
+  id: number,
+  data: { name: string; value: string }
+) => {
+  return prisma.appVariable.update({
+    where: { id },
+    data,
+  });
+};

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export const updateUserNotificationStatus = async (
+  userId: number,
+  read: boolean
+) => {
+  const result = await prisma.notification.updateMany({
+    where: { user_id: userId },
+    data: { read },
+  });
+  return result.count;
+};
+
+export const deleteAllNotificationsForUser = async (userId: number) => {
+  const result = await prisma.notification.deleteMany({
+    where: { user_id: userId },
+  });
+  return result.count;
+};

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,39 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export const createUser = async (data: { name: string; email: string; password: string }) => {
+  return prisma.user.create({ data });
+};
+
+export const updateUserById = async (
+  id: number,
+  data: { name?: string; email?: string; status?: boolean }
+) => {
+  return prisma.user.update({
+    where: { id },
+    data,
+  });
+};
+
+export const toggleUserStatus = async (id: number) => {
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) throw new Error("User not found");
+  return prisma.user.update({
+    where: { id },
+    data: { status: !user.status },
+  });
+};
+
+export const softDeleteUser = async (id: number) => {
+  return prisma.user.update({
+    where: { id },
+    data: { deleted_at: new Date() },
+  });
+};
+
+export const changeUserPassword = async (userId: number, newPassword: string) => {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { password: newPassword },
+  });
+};


### PR DESCRIPTION
## Summary
- move all write queries from repositories to services
- repositories now expose only data fetching operations
- services perform create, update and delete using Prisma

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687683e7b008832493d013251d798fde