### PR TITLE
Fix tsconfig path resolution during dev

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -2,7 +2,7 @@
   "watch": ["src"],
   "ext": "ts",
   "ignore": ["dist", "tests", "node_modules"],
-  "exec": "ts-node src/index.ts",
+  "exec": "ts-node -r tsconfig-paths/register src/index.ts",
   "env": {
     "NODE_ENV": "development"
   }


### PR DESCRIPTION
## Summary
- ensure nodemon loads tsconfig paths by passing `-r tsconfig-paths/register`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b7d96630832494c2d8c75bae7470