### PR TITLE
Fix rootDir to compile tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
       "@scripts/*": ["scripts/*"]
     },
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- fix tsconfig rootDir so tsc can compile files outside src

## Testing
- `npm test` *(fails: jest not found)*
- `npx --no-install tsc` *(fails: cannot find type definitions)*


------
https://chatgpt.com/codex/tasks/task_e_6879197a846083248cd8fe16de3584b5