### PR TITLE
Fix import paths and adjust tests for service layer

### DIFF
--- a/src/domain/interfaces/user.repository.interface.ts
+++ b/src/domain/interfaces/user.repository.interface.ts
@@ -1,4 +1,4 @@
-import { UserEntity } from "@/entities/user.entity";
+import { UserEntity } from "@/domain/entities/user.entity";
 
 export interface IUserRepository {
     findByEmail(email: string): Promise<UserEntity | null>;

--- a/src/events/listeners/admin.listener.ts
+++ b/src/events/listeners/admin.listener.ts
@@ -1,4 +1,4 @@
-import { appEmitter, APP_EVENTS } from "@/events/emitters/userEmitter";
+import { appEmitter, APP_EVENTS } from "@/events/emitters/appEmitter";
 import { logger } from "@/utils/logger";
 
 appEmitter.on(APP_EVENTS.ADMIN_LOGGED_IN, (payload) => {

--- a/src/events/listeners/user.listener.ts
+++ b/src/events/listeners/user.listener.ts
@@ -1,4 +1,4 @@
-import { appEmitter, APP_EVENTS } from "@/events/emitters/userEmitter";
+import { appEmitter, APP_EVENTS } from "@/events/emitters/appEmitter";
 import { sendEmail } from "@utils/mailer";
 import { userWelcomeEmail } from "@/templates/mail/userWelcomeEmail";
 import { emailQueue } from "@/jobs/queues/email.queue";

--- a/tests/routes/adminUserRoutes.test.ts
+++ b/tests/routes/adminUserRoutes.test.ts
@@ -1,8 +1,8 @@
 import { createAuthTestServer, AuthTestServer } from '@tests/helpers/expressAuthTestHelper';
 import adminUserRoutes from '@/routes/admin/user';
-import * as userRepo from '@/repositories/user.repository';
+import * as userService from '@/services/user.service';
 
-jest.mock('@/repositories/user.repository');
+jest.mock('@/services/user.service');
 
 let server: AuthTestServer;
 
@@ -17,7 +17,7 @@ beforeEach(() => {
 describe('Admin User Routes', () => {
   describe('GET /api/admin/user/users', () => {
     it('should list users', async () => {
-      (userRepo.getAllUsers as jest.Mock).mockResolvedValueOnce([]);
+      (userService.getAllUsers as jest.Mock).mockResolvedValueOnce([]);
       const res = await server.request.get('/api/admin/user/users');
       expect(res.status).toBe(200);
     });
@@ -29,7 +29,7 @@ describe('Admin User Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (userRepo.getAllUsers as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (userService.getAllUsers as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request.get('/api/admin/user/users');
       expect(res.status).toBe(500);
     });
@@ -37,7 +37,7 @@ describe('Admin User Routes', () => {
 
   describe('POST /api/admin/user/users/:id/update', () => {
     it('should update user', async () => {
-      (userRepo.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1 });
+      (userService.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1 });
       const res = await server.request
         .post('/api/admin/user/users/1/update')
         .send({ name: 'John' });
@@ -52,7 +52,7 @@ describe('Admin User Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (userRepo.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (userService.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request
         .post('/api/admin/user/users/1/update')
         .send({ name: 'John' });
@@ -62,7 +62,7 @@ describe('Admin User Routes', () => {
 
   describe('GET /api/admin/user/users/:id/toggle', () => {
     it('should toggle user status', async () => {
-      (userRepo.toggleUserStatus as jest.Mock).mockResolvedValueOnce({ id: 1, status: true });
+      (userService.toggleUserStatus as jest.Mock).mockResolvedValueOnce({ id: 1, status: true });
       const res = await server.request.get('/api/admin/user/users/1/toggle');
       expect(res.status).toBe(200);
     });
@@ -73,7 +73,7 @@ describe('Admin User Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (userRepo.toggleUserStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (userService.toggleUserStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request.get('/api/admin/user/users/1/toggle');
       expect(res.status).toBe(500);
     });
@@ -81,7 +81,7 @@ describe('Admin User Routes', () => {
 
   describe('GET /api/admin/user/users/:id/delete', () => {
     it('should delete user', async () => {
-      (userRepo.softDeleteUser as jest.Mock).mockResolvedValueOnce({ id: 1 });
+      (userService.softDeleteUser as jest.Mock).mockResolvedValueOnce({ id: 1 });
       const res = await server.request.get('/api/admin/user/users/1/delete');
       expect(res.status).toBe(200);
     });
@@ -92,7 +92,7 @@ describe('Admin User Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (userRepo.softDeleteUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (userService.softDeleteUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request.get('/api/admin/user/users/1/delete');
       expect(res.status).toBe(500);
     });

--- a/tests/routes/authRoutes.test.ts
+++ b/tests/routes/authRoutes.test.ts
@@ -1,12 +1,14 @@
 import { createTestServer, TestServer } from '@tests/helpers/expressTestHelper';
 import authRoutes from '@/routes/user/auth';
 import * as userRepo from '@/repositories/user.repository';
+import * as userService from '@/services/user.service';
 import * as hashUtils from '@/utils/hash';
 import * as otpUtils from '@/utils/otp';
 import * as resetTokenUtils from '@/utils/resetToken';
 import { logAppleCheck } from '@/jobs/logAppleCheck';
 
 jest.mock('@/repositories/user.repository');
+jest.mock('@/services/user.service');
 jest.mock('@/utils/hash');
 jest.mock('@/utils/otp');
 jest.mock('@/utils/resetToken');
@@ -27,7 +29,7 @@ describe('Auth Routes', () => {
     it('should register a new user', async () => {
       (userRepo.findUserByEmail as jest.Mock).mockResolvedValueOnce(null);
       (hashUtils.hashPassword as jest.Mock).mockResolvedValueOnce('hashed');
-      (userRepo.createUser as jest.Mock).mockResolvedValueOnce({
+      (userService.createUser as jest.Mock).mockResolvedValueOnce({
         id: 1,
         name: 'John',
         email: 'john@example.com',

--- a/tests/routes/notificationRoutes.test.ts
+++ b/tests/routes/notificationRoutes.test.ts
@@ -1,9 +1,11 @@
 import { createAuthTestServer, AuthTestServer } from '@tests/helpers/expressAuthTestHelper';
 import notificationRoutes from '@/routes/user/notification';
 import * as notifRepo from '@/repositories/notification.repository';
+import * as notifService from '@/services/notification.service';
 import * as notifJobs from '@/jobs/notification.jobs';
 
 jest.mock('@/repositories/notification.repository');
+jest.mock('@/services/notification.service');
 jest.mock('@/jobs/notification.jobs');
 
 let server: AuthTestServer;
@@ -39,7 +41,7 @@ describe('Notification Routes', () => {
 
   describe('GET /api/user/notifications/status/change/:status', () => {
     it('should update notification status', async () => {
-      (notifRepo.updateUserNotificationStatus as jest.Mock).mockResolvedValueOnce(1);
+      (notifService.updateUserNotificationStatus as jest.Mock).mockResolvedValueOnce(1);
       const res = await server.request.get('/api/user/notifications/status/change/read');
       expect(res.status).toBe(200);
     });
@@ -50,7 +52,7 @@ describe('Notification Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (notifRepo.updateUserNotificationStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (notifService.updateUserNotificationStatus as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request.get('/api/user/notifications/status/change/read');
       expect(res.status).toBe(500);
     });
@@ -58,13 +60,13 @@ describe('Notification Routes', () => {
 
   describe('GET /api/user/notifications/clear-all', () => {
     it('should clear notifications', async () => {
-      (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockResolvedValueOnce(3);
+      (notifService.deleteAllNotificationsForUser as jest.Mock).mockResolvedValueOnce(3);
       const res = await server.request.get('/api/user/notifications/clear-all');
       expect(res.status).toBe(200);
     });
 
     it('should handle server errors', async () => {
-      (notifRepo.deleteAllNotificationsForUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      (notifService.deleteAllNotificationsForUser as jest.Mock).mockRejectedValueOnce(new Error('fail'));
       const res = await server.request.get('/api/user/notifications/clear-all');
       expect(res.status).toBe(500);
     });

--- a/tests/routes/profileRoutes.test.ts
+++ b/tests/routes/profileRoutes.test.ts
@@ -1,8 +1,10 @@
 import { createAuthTestServer, AuthTestServer } from '@tests/helpers/expressAuthTestHelper';
 import profileRoutes from '@/routes/user/profile';
 import * as userRepo from '@/repositories/user.repository';
+import * as userService from '@/services/user.service';
 
 jest.mock('@/repositories/user.repository');
+jest.mock('@/services/user.service');
 
 let server: AuthTestServer;
 
@@ -43,7 +45,7 @@ describe('Profile Routes', () => {
 
   describe('POST /api/user/update', () => {
     it('should update user profile', async () => {
-      (userRepo.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
+      (userService.updateUserById as jest.Mock).mockResolvedValueOnce({ id: 1, name: 'John', email: 'john@example.com' });
       const res = await server.request.post('/api/user/update').send({ name: 'John', email: 'john@example.com' });
       expect(res.status).toBe(200);
     });
@@ -54,7 +56,7 @@ describe('Profile Routes', () => {
     });
 
     it('should handle server errors', async () => {
-      (userRepo.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
+      (userService.updateUserById as jest.Mock).mockRejectedValueOnce(new Error('db'));
       const res = await server.request.post('/api/user/update').send({ name: 'John', email: 'john@example.com' });
       expect(res.status).toBe(500);
     });


### PR DESCRIPTION
## Summary
- correct entity import path for user repository interface
- point admin/user event listeners to `appEmitter`
- update route tests to mock service-layer functions

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791e8aade08324bd1c0ede6488159d