### PR TITLE
Handle missing sessions in logout

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -7,6 +7,11 @@ export const generateSession = async (req: any, userId: number, role: "user" | "
 
 export const destroySession = (req: any): Promise<void> => {
   return new Promise((resolve, reject) => {
+    if (!req.session || typeof req.session.destroy !== "function") {
+      // No active session to destroy
+      return resolve();
+    }
+
     req.session.destroy((err: any) => {
       if (err) return reject(err);
       resolve();


### PR DESCRIPTION
## Summary
- ensure logout does not error when no session exists

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879271f55148324a7a7915473a99003