### PR TITLE
Introduce microservice folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ tests/                   # Jest + Supertest suites
 
 ---
 
+## Microservices Architecture
+
+The repository follows a microservice approach. All microservice code sits
+inside the top level `services` directory. Services are grouped by `user` and
+`admin` modules:
+
+- `services/admin/admin-auth-service` – admin authentication
+- `services/admin/admin-user-service` – admin user management & exports
+- `services/admin/admin-notification-service` – admin notifications
+- `services/admin/admin-service` – remaining admin features
+- `services/user/user-auth-service` – user authentication
+- `services/user/user-service` – other user endpoints
+- `services/gateway` – lightweight proxy that routes requests to the
+  appropriate service
+
+Run each service individually with the scripts listed in `package.json` or start
+the gateway (default `npm run dev`) to proxy requests on port `3000`.
+
+---
+
 ## 🛠 Installation
 
 Install the dependencies:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a starter kit for building APIs using Node.js, TypeScript, Prisma, and Redis.",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "nodemon --require tsconfig-paths/register src/index.ts",
+    "dev": "ts-node services/gateway/src/server.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "seed": "ts-node prisma/seed.ts",
@@ -12,7 +12,14 @@
     "worker": "ts-node -r tsconfig-paths/register scripts/worker.ts",
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
-    "prisma:studio": "npx prisma studio"
+    "prisma:studio": "npx prisma studio",
+    "dev:gateway": "ts-node services/gateway/src/server.ts",
+    "dev:user": "ts-node services/user/user-service/src/server.ts",
+    "dev:admin": "ts-node services/admin/admin-service/src/server.ts",
+    "dev:admin-auth": "ts-node services/admin/admin-auth-service/src/server.ts",
+    "dev:admin-user": "ts-node services/admin/admin-user-service/src/server.ts",
+    "dev:admin-notification": "ts-node services/admin/admin-notification-service/src/server.ts",
+    "dev:user-auth": "ts-node services/user/user-auth-service/src/server.ts"
   },
   "dependencies": {
     "@bull-board/api": "^4.10.0",

--- a/services/admin/admin-auth-service/src/server.ts
+++ b/services/admin/admin-auth-service/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+import authRoutes from '../../../../src/routes/admin/auth';
+import { globalErrorHandler } from '../../../../src/middlewares/errorHandler';
+
+export const startAdminAuthService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+  app.use('/api/admin/auth', authRoutes);
+  app.use(globalErrorHandler);
+
+  const PORT = process.env.ADMIN_AUTH_PORT || 4010;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`Admin auth service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startAdminAuthService();
+}

--- a/services/admin/admin-auth-service/tsconfig.json
+++ b/services/admin/admin-auth-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/admin/admin-notification-service/src/server.ts
+++ b/services/admin/admin-notification-service/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+
+export const startAdminNotificationService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+
+  app.get('/api/admin/notifications', (_req, res) => {
+    res.json({ message: 'Admin notifications placeholder' });
+  });
+
+  const PORT = process.env.ADMIN_NOTIFICATION_PORT || 4012;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`Admin notification service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startAdminNotificationService();
+}

--- a/services/admin/admin-notification-service/tsconfig.json
+++ b/services/admin/admin-notification-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/admin/admin-service/src/server.ts
+++ b/services/admin/admin-service/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+import adminRoutes from '../../../../src/api/admin.routes';
+import { globalErrorHandler } from '../../../../src/middlewares/errorHandler';
+
+export const startAdminService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+  app.use('/api/admin', adminRoutes);
+  app.use(globalErrorHandler);
+
+  const PORT = process.env.ADMIN_PORT || 4002;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`Admin service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startAdminService();
+}

--- a/services/admin/admin-service/tsconfig.json
+++ b/services/admin/admin-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/admin/admin-user-service/src/server.ts
+++ b/services/admin/admin-user-service/src/server.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+import userRoutes from '../../../../src/routes/admin/user';
+import exportRoutes from '../../../../src/routes/admin/export';
+import { globalErrorHandler } from '../../../../src/middlewares/errorHandler';
+
+export const startAdminUserService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+  app.use('/api/admin/user', userRoutes);
+  app.use('/api/admin/user', exportRoutes);
+  app.use(globalErrorHandler);
+
+  const PORT = process.env.ADMIN_USER_PORT || 4011;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`Admin user service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startAdminUserService();
+}

--- a/services/admin/admin-user-service/tsconfig.json
+++ b/services/admin/admin-user-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+
+
+function createProxy(target: string) {
+  return async (req: express.Request, res: express.Response) => {
+    const url = `${target}${req.originalUrl}`;
+    const headers: Record<string, any> = { ...req.headers };
+    delete headers['host'];
+    const init: any = {
+      method: req.method,
+      headers,
+    };
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      init.body = JSON.stringify(req.body);
+      if (!headers['content-type']) {
+        init.headers = { ...headers, 'content-type': 'application/json' };
+      }
+    }
+    const resp = await fetch(url, init);
+    res.status(resp.status);
+    resp.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    const data = await resp.text();
+    res.send(data);
+  };
+}
+
+export const startGateway = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+
+  app.use('/api/user', createProxy('http://localhost:4001'));
+  app.use('/api/admin', createProxy('http://localhost:4002'));
+
+  const PORT = process.env.GATEWAY_PORT || 3000;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`Gateway running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startGateway();
+}

--- a/services/gateway/tsconfig.json
+++ b/services/gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/user/user-auth-service/src/server.ts
+++ b/services/user/user-auth-service/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+import authRoutes from '../../../../src/routes/user/auth';
+import { globalErrorHandler } from '../../../../src/middlewares/errorHandler';
+
+export const startUserAuthService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+  app.use('/api/user/auth', authRoutes);
+  app.use(globalErrorHandler);
+
+  const PORT = process.env.USER_AUTH_PORT || 4003;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`User auth service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startUserAuthService();
+}

--- a/services/user/user-auth-service/tsconfig.json
+++ b/services/user/user-auth-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/services/user/user-service/src/server.ts
+++ b/services/user/user-service/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import { createServer, Server } from 'http';
+import userRoutes from '../../../../src/api/user.routes';
+import { globalErrorHandler } from '../../../../src/middlewares/errorHandler';
+
+export const startUserService = async (): Promise<Server> => {
+  const app = express();
+  const httpServer = createServer(app);
+
+  app.use(helmet());
+  app.use(compression());
+  app.use(express.json());
+  app.use('/api/user', userRoutes);
+  app.use(globalErrorHandler);
+
+  const PORT = process.env.USER_PORT || 4001;
+  await new Promise<void>((resolve) => {
+    httpServer.listen(PORT, () => {
+      console.log(`User service running on http://localhost:${PORT}`);
+      resolve();
+    });
+  });
+
+  return httpServer;
+};
+
+if (require.main === module) {
+  startUserService();
+}

--- a/services/user/user-service/tsconfig.json
+++ b/services/user/user-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import "@/types/express";
 import "@/config/env";
 import { initSentry } from "@/telemetry/sentry";
-import { startServer } from "@/server";
+import { startGateway } from "../services/gateway/src/server";
 import { logger } from "@/utils/logger";
 import "@/events/listeners/otpListener";
 
@@ -11,7 +11,7 @@ import "@/events/listeners/otpListener";
 initSentry();
 
 async function bootstrap() {
-  const server = await startServer();
+  const server = await startGateway();
 
   const shutdown = () => {
     logger.info("🛑 Shutting down server");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     "noImplicitAny": false,
     "types": ["node", "jest"]
   },
-  "include": ["src", "tests", "prisma/seed.ts"],
+  "include": ["src", "tests", "prisma/seed.ts", "services"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- group all microservices under `services` directory
- update start scripts to use the new locations
- document new folder structure in README
- launch gateway from new folder in `src/index.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68792c67b4d88324a61a9ab9844643d4