### PR TITLE
Remove Dockerfiles and attach routes per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ src/                     # Application source
 prisma/                  # Prisma schema, migrations and seeds
 scripts/                 # Helper scripts (workers, CLI utilities)
 tests/                   # Jest + Supertest suites
+services/               # Independent microservice packages
+  auth/
+    src/
+  users/
+    src/
+  notifications/
+    src/
+  gateway/
+    src/
+  common/
+    src/
 ```
 
 ---
@@ -96,6 +107,16 @@ npm run dev
 ```
 
 `nodemon.json` watches the `src` folder and runs `ts-node` on changes.
+
+### Run All Microservices
+
+```bash
+npm run microservices
+```
+
+This starts the gateway, auth, users and notifications services on ports 3000-3003.
+
+Each service relies on packages from the root `node_modules` folder. Run `npm install` once at the project root before starting the microservices.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "seed": "ts-node prisma/seed.ts",
     "test": "jest",
     "worker": "ts-node -r tsconfig-paths/register scripts/worker.ts",
+    "microservices": "ts-node scripts/start-services.ts",
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
     "prisma:studio": "npx prisma studio"
@@ -36,6 +37,7 @@
     "redis": "^4.6.7",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "http-proxy-middleware": "^2.0.6",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/scripts/start-services.ts
+++ b/scripts/start-services.ts
@@ -1,0 +1,26 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+const services = ['auth', 'users', 'notifications', 'gateway'];
+const processes: { name: string; proc: ReturnType<typeof spawn> }[] = [];
+
+for (const service of services) {
+  const servicePath = path.join(__dirname, '..', 'services', service);
+  const proc = spawn('npm', ['run', 'start'], {
+    cwd: servicePath,
+    stdio: 'inherit',
+    shell: true,
+  });
+  processes.push({ name: service, proc });
+}
+
+function shutdown() {
+  for (const { proc } of processes) {
+    proc.kill();
+  }
+  process.exit();
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "auth-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "common": "file:../common"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import userRoutes from '@/api/user.routes';
+import adminRoutes from '@/api/admin.routes';
+import { shared } from '../common/src/index';
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/user', userRoutes);
+app.use('/api/admin', adminRoutes);
+
+app.get('/health', (_req, res) =>
+  res.json({ status: 'auth ok', util: shared() })
+);
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Auth service running on port ${PORT}`);
+});

--- a/services/auth/tsconfig.json
+++ b/services/auth/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "../common/src"]
+}

--- a/services/common/package.json
+++ b/services/common/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "common",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/common/src/index.ts
+++ b/services/common/src/index.ts
@@ -1,0 +1,1 @@
+export const shared = () => 'common utilities';

--- a/services/common/tsconfig.json
+++ b/services/common/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gateway-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "common": "file:../common",
+    "http-proxy-middleware": "^2.0.6"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import { shared } from '../common/src/index';
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', createProxyMiddleware({ target: 'http://localhost:3001', changeOrigin: true }));
+app.use('/users', createProxyMiddleware({ target: 'http://localhost:3002', changeOrigin: true }));
+app.use('/notifications', createProxyMiddleware({ target: 'http://localhost:3003', changeOrigin: true }));
+
+app.get('/health', (_req, res) => res.json({ status: 'gateway ok', util: shared() }));
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Gateway service running on port ${PORT}`);
+});

--- a/services/gateway/tsconfig.json
+++ b/services/gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "../common/src"]
+}

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "notifications-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "common": "file:../common"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import userRoutes from '@/api/user.routes';
+import adminRoutes from '@/api/admin.routes';
+import { shared } from '../common/src/index';
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/user', userRoutes);
+app.use('/api/admin', adminRoutes);
+
+app.get('/health', (_req, res) =>
+  res.json({ status: 'notifications ok', util: shared() })
+);
+
+const PORT = process.env.PORT || 3003;
+app.listen(PORT, () => {
+  console.log(`Notifications service running on port ${PORT}`);
+});

--- a/services/notifications/tsconfig.json
+++ b/services/notifications/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "../common/src"]
+}

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "users-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "common": "file:../common"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/users/src/index.ts
+++ b/services/users/src/index.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import userRoutes from '@/api/user.routes';
+import adminRoutes from '@/api/admin.routes';
+import { shared } from '../common/src/index';
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/user', userRoutes);
+app.use('/api/admin', adminRoutes);
+
+app.get('/health', (_req, res) =>
+  res.json({ status: 'users ok', util: shared() })
+);
+
+const PORT = process.env.PORT || 3002;
+app.listen(PORT, () => {
+  console.log(`Users service running on port ${PORT}`);
+});

--- a/services/users/tsconfig.json
+++ b/services/users/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "../common/src"]
+}


### PR DESCRIPTION
## Summary
- remove Docker and compose files
- extend root tsconfig in microservices
- wire user/admin routes in each service
- add gateway proxy routes
- depend on shared common package across services
- add helper to launch all microservices
- fix imports and include paths for common package
- document installing deps before `npm run microservices`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793c557e64832487c473ce97d943ce