### PR TITLE
feat: add media library with pluggable storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,44 @@ GET /admin/export/users/xlsx
 
 ---
 
+## 📚 Media Library Examples
+
+Use the built–in media endpoints to attach files to any model.
+
+```http
+# Upload a single avatar for user 1
+POST /api/media/users/1/avatar  (file field: "file")
+
+# Upload multiple gallery images for post 5
+POST /api/media/posts/5/gallery/batch  (file field: "files")
+
+# Attach a document to order 9
+POST /api/media/orders/9/documents  (file field: "file")
+```
+
+Each response contains the persisted media id and a publicly accessible URL.
+
+### Collections & Conversions
+
+Configure collections and image conversions in `src/config/media-collections.ts`:
+
+```ts
+export const mediaCollections = {
+  avatar: {
+    singleFile: true,
+    conversions: [{ name: 'thumb', width: 200, height: 200 }],
+    acceptsMimeTypes: ['image/png', 'image/jpeg'],
+    fallbackUrl: '/images/default-avatar.png',
+  },
+  gallery: { maxFiles: 10 },
+};
+```
+
+Uploaded images for the `avatar` collection will store an extra `thumb` conversion.
+Use `mediaService.urlFor(media, 'thumb')` to retrieve the resized image.
+
+---
+
 ## 📦 Build & Start Production
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "socket.io-client": "^4.8.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "multer": "^1.4.5-lts.1",
+    "@aws-sdk/client-s3": "^3.546.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@json2csv/node": "^7.0.6",
@@ -63,7 +66,8 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.4.5",
     "xlsx": "^0.18.5",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "@types/multer": "^1.4.11"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,4 +256,27 @@ model Notification {
   user       User     @relation(fields: [user_id], references: [id])
 }
 
+model Media {
+  id                   BigInt    @id @default(autoincrement())
+  model_type           String
+  model_id             BigInt
+  uuid                 String?   @unique @db.Char(36)
+  collection_name      String
+  name                 String
+  file_name            String
+  mime_type            String?
+  disk                 String
+  conversions_disk     String?
+  size                 BigInt
+  manipulations        String     @db.LongText @default("{}")
+  custom_properties    String     @db.LongText @default("{}")
+  generated_conversions String    @db.LongText @default("{}")
+  responsive_images    String     @db.LongText @default("{}")
+  order_column         Int?
+  created_at           DateTime?  @default(now())
+  updated_at           DateTime?  @updatedAt
+
+  @@map("media")
+}
+
 

--- a/src/adapters/storage/LocalStorage.ts
+++ b/src/adapters/storage/LocalStorage.ts
@@ -1,0 +1,25 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { Storage } from './Storage';
+
+export class LocalStorage implements Storage {
+  constructor(private root: string) {}
+
+  async put(filePath: string, content: Buffer): Promise<void> {
+    const fullPath = path.join(this.root, filePath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+
+  async delete(filePath: string): Promise<void> {
+    const fullPath = path.join(this.root, filePath);
+    await fs.unlink(fullPath).catch(() => undefined);
+  }
+
+  url(filePath: string): string {
+    const base = process.env.APP_URL || '';
+    // assuming express serves this.root as '/uploads'
+    const prefix = process.env.LOCAL_STORAGE_URL_PREFIX || '/uploads';
+    return `${base}${prefix}/${filePath}`.replace(/\+/g, '/');
+  }
+}

--- a/src/adapters/storage/S3Storage.ts
+++ b/src/adapters/storage/S3Storage.ts
@@ -1,0 +1,24 @@
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import type { Storage } from './Storage';
+
+export class S3Storage implements Storage {
+  constructor(private client: any, private bucket: string, private baseUrl?: string) {}
+
+  async put(path: string, content: Buffer, mimeType: string): Promise<void> {
+    await this.client.send(
+      new PutObjectCommand({ Bucket: this.bucket, Key: path, Body: content, ContentType: mimeType })
+    );
+  }
+
+  async delete(path: string): Promise<void> {
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: path }));
+  }
+
+  url(path: string): string {
+    if (this.baseUrl) {
+      return `${this.baseUrl.replace(/\/$/, '')}/${path}`;
+    }
+    const region = process.env.AWS_REGION;
+    return `https://${this.bucket}.s3.${region}.amazonaws.com/${path}`;
+  }
+}

--- a/src/adapters/storage/Storage.ts
+++ b/src/adapters/storage/Storage.ts
@@ -1,0 +1,5 @@
+export interface Storage {
+  put(path: string, content: Buffer, mimeType: string): Promise<void>;
+  delete(path: string): Promise<void>;
+  url(path: string): string;
+}

--- a/src/api/media.routes.ts
+++ b/src/api/media.routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import mediaRoutes from '@/routes/media';
+
+const router = Router();
+router.use('/', mediaRoutes);
+
+export default router;

--- a/src/config/media-collections.ts
+++ b/src/config/media-collections.ts
@@ -1,0 +1,27 @@
+export interface MediaConversion {
+  name: string;
+  width?: number;
+  height?: number;
+}
+
+export interface MediaCollectionOptions {
+  singleFile?: boolean;
+  maxFiles?: number;
+  acceptsMimeTypes?: string[];
+  acceptsExtensions?: string[];
+  fallbackUrl?: string;
+  conversions?: MediaConversion[];
+}
+
+export const mediaCollections: Record<string, MediaCollectionOptions> = {
+  avatar: {
+    singleFile: true,
+    conversions: [{ name: 'thumb', width: 200, height: 200 }],
+    acceptsMimeTypes: ['image/png', 'image/jpeg'],
+    fallbackUrl: '/images/default-avatar.png',
+  },
+  gallery: {
+    maxFiles: 10,
+  },
+  documents: {},
+};

--- a/src/config/storage.config.ts
+++ b/src/config/storage.config.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { S3Client } from '@aws-sdk/client-s3';
+import { LocalStorage } from '@/adapters/storage/LocalStorage';
+import { S3Storage } from '@/adapters/storage/S3Storage';
+import type { Storage } from '@/adapters/storage/Storage';
+
+export const createStorage = (): Storage => {
+  const driver = process.env.STORAGE_DRIVER || 'local';
+  if (driver === 's3') {
+    const client = new S3Client({ region: process.env.AWS_REGION });
+    return new S3Storage(client, process.env.AWS_S3_BUCKET!, process.env.AWS_S3_BASE_URL);
+  }
+  const root = process.env.LOCAL_STORAGE_PATH || path.join(process.cwd(), 'uploads');
+  return new LocalStorage(root);
+};

--- a/src/controllers/media.controller.ts
+++ b/src/controllers/media.controller.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { createStorage } from '@/config/storage.config';
+import { mediaCollections } from '@/config/media-collections';
+import { MediaService, UploadedFile } from '@/services/media.service';
+import { asyncHandler } from '@/utils/asyncHandler';
+import { success } from '@/utils/responseWrapper';
+
+const prisma = new PrismaClient();
+const mediaService = new MediaService(prisma, createStorage(), mediaCollections);
+
+export const uploadSingle = asyncHandler(async (req: Request, res: Response) => {
+  const { modelType, modelId, collection } = req.params as any;
+  const file = (req as any).file as UploadedFile | undefined;
+  if (!file) {
+    return res.status(400).json({ error: 'file is required' });
+  }
+  const media = await mediaService.attachFile({
+    file,
+    modelType,
+    modelId: Number(modelId),
+    collection,
+  });
+  res.json(success('uploaded', { id: Number(media.id), url: mediaService.urlFor(media) }));
+});
+
+export const uploadMultiple = asyncHandler(async (req: Request, res: Response) => {
+  const { modelType, modelId, collection } = req.params as any;
+  const files = (req as any).files as UploadedFile[];
+  if (!files || files.length === 0) {
+    return res.status(400).json({ error: 'files are required' });
+  }
+  const results: Array<{ id: number; url: string }> = [];
+  for (const file of files) {
+    const media = await mediaService.attachFile({
+      file,
+      modelType,
+      modelId: Number(modelId),
+      collection,
+    });
+    results.push({ id: Number(media.id), url: mediaService.urlFor(media) });
+  }
+  res.json(success('uploaded', results));
+});
+
+export const listByModel = asyncHandler(async (req: Request, res: Response) => {
+  const { modelType, modelId } = req.params as any;
+  const list = await mediaService.listByModel(modelType, Number(modelId));
+  const result = list.map((m) => ({ id: Number(m.id), url: mediaService.urlFor(m) }));
+  res.json(success('ok', result));
+});
+
+export const deleteMedia = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params as any;
+  await mediaService.delete(Number(id));
+  res.json(success('deleted'));
+});
+
+export const updateCustomProps = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params as any;
+  const { custom } = req.body as any;
+  await mediaService.updateCustomProps(Number(id), custom ?? {});
+  res.json(success('updated'));
+});

--- a/src/requests/media.request.ts
+++ b/src/requests/media.request.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const MediaParamsSchema = z.object({
+  modelType: z.string().min(1),
+  modelId: z.string().regex(/^\d+$/),
+  collection: z.string().min(1),
+});
+
+export const MediaModelParamsSchema = z.object({
+  modelType: z.string().min(1),
+  modelId: z.string().regex(/^\d+$/),
+});
+
+export const MediaIdParamSchema = z.object({
+  id: z.string().regex(/^\d+$/),
+});
+
+export const UpdateCustomPropsSchema = z.object({
+  custom: z.record(z.any()),
+});

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,0 +1,53 @@
+import { Router } from 'express';
+import multer from 'multer';
+import {
+  uploadSingle,
+  uploadMultiple,
+  listByModel,
+  deleteMedia,
+  updateCustomProps,
+} from '@/controllers/media.controller';
+import validateRequest from '@/middlewares/validateRequest';
+import {
+  MediaParamsSchema,
+  MediaModelParamsSchema,
+  MediaIdParamSchema,
+  UpdateCustomPropsSchema,
+} from '@/requests/media.request';
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.post(
+  '/:modelType/:modelId/:collection',
+  validateRequest({ params: MediaParamsSchema }),
+  upload.single('file'),
+  uploadSingle
+);
+
+router.post(
+  '/:modelType/:modelId/:collection/batch',
+  validateRequest({ params: MediaParamsSchema }),
+  upload.array('files'),
+  uploadMultiple
+);
+
+router.get(
+  '/:modelType/:modelId',
+  validateRequest({ params: MediaModelParamsSchema }),
+  listByModel
+);
+
+router.delete(
+  '/:id',
+  validateRequest({ params: MediaIdParamSchema }),
+  deleteMedia
+);
+
+router.patch(
+  '/:id/custom',
+  validateRequest({ params: MediaIdParamSchema, body: UpdateCustomPropsSchema }),
+  updateCustomProps
+);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { StatusCode } from "@/constants/statusCodes";
 // Routes
 import userRoutes from "@/api/user.routes";
 import adminRoutes from "@/api/admin.routes";
+import mediaRoutes from "@/api/media.routes";
 import healthRoutes from "@/api/health.routes";
 import docsRoutes from "@/api/docs.routes";
 import bullBoardRoutes from "@/api/bull.routes";
@@ -105,6 +106,9 @@ export const startServer = async (): Promise<Server> => {
 
   // Health check
   app.use("/api/health", healthRoutes);
+
+  // Media routes
+  app.use("/api/media", mediaRoutes);
 
   // User routes
   app.use("/api/user", userRoutes);

--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -1,0 +1,2 @@
+declare module 'multer';
+declare module '@aws-sdk/client-s3';


### PR DESCRIPTION
## Summary
- add configurable media collections with validation and fallback URLs
- generate image conversions and expose helper URLs
- document collection setup and conversion usage

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@/repositories/user.repository' from various tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b477c0e248324bb462b0c9d704137